### PR TITLE
Feature/favorite_projects_with_external_package

### DIFF
--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -25,15 +25,15 @@ class Project extends Model
     {
         return $this->belongsTo(Customer::class);
     }
-    
+
     public function epics()
     {
         return $this->hasMany(Epic::class);
     }
-    
+
     public function tagEpics()
     {
-        return $this->belongsToMany(Epic::class,'epic_project_tags');
+        return $this->belongsToMany(Epic::class, 'epic_project_tags');
     }
 
     public function stories()
@@ -50,6 +50,12 @@ class Project extends Model
     {
         return $this->hasMany(Story::class)->whereNull('epic_id');
     }
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
+
 
     /**
      * Returns the SAL of the milestone

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,6 +70,12 @@ class User extends Authenticatable
         return $this->hasMany(Epic::class);
     }
 
+    public function projects()
+    {
+        return $this->belongsToMany(Project::class);
+    }
+
+
     /**
      * Determine if the user can impersonate another user.
      *

--- a/app/Nova/Actions/RemoveFromFavoritesAction.php
+++ b/app/Nova/Actions/RemoveFromFavoritesAction.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Nova\Actions;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class RemoveFromFavoritesAction extends Action
+{
+    use InteractsWithQueue, Queueable;
+
+    /**
+     * The displayable name of the action.
+     *
+     * @var string
+     */
+    public $name = 'Remove from favorites';
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param  \Laravel\Nova\Fields\ActionFields  $fields
+     * @param  \Illuminate\Support\Collection  $models
+     * @return mixed
+     */
+    public function handle(ActionFields $fields, Collection $models)
+    {
+        //detach the selected projects from the user
+        $models->each(function ($model) {
+            $model->users()->detach(auth()->user()->id);
+            $model->save();
+        });
+
+        return Action::message('The selected projects have been removed from your favorites. Please refresh the page to see the changes.');
+    }
+
+    /**
+     * Get the fields available on the action.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function fields(NovaRequest $request)
+    {
+        return [];
+    }
+}

--- a/app/Nova/Dashboards/Main.php
+++ b/app/Nova/Dashboards/Main.php
@@ -66,7 +66,7 @@ class Main extends Dashboard
             }),
 
             (new NovaResourceCard('\App\Nova\FavoriteProjects'))
-                ->width('2/3')
+                ->width('full')
                 ->setFooterLinkLabel(__('Attach projects to your favorites'))
                 ->setFooterLinkExternalUrl($url)
         ];

--- a/app/Nova/Dashboards/Main.php
+++ b/app/Nova/Dashboards/Main.php
@@ -3,15 +3,16 @@
 namespace App\Nova\Dashboards;
 
 use App\Enums\UserRole;
-use App\Nova\Metrics\TotApps;
 use Laravel\Nova\Cards\Help;
-use App\Nova\Metrics\TotCustomers;
+use App\Nova\Metrics\TotApps;
 use App\Nova\Metrics\TotEpics;
 use App\Nova\Metrics\TotLayers;
-use App\Nova\Metrics\TotMilestones;
-use App\Nova\Metrics\TotProjects;
 use App\Nova\Metrics\TotStories;
+use App\Nova\Metrics\TotProjects;
+use App\Nova\Metrics\TotCustomers;
+use App\Nova\Metrics\TotMilestones;
 use Laravel\Nova\Dashboards\Main as Dashboard;
+use NormanHuth\NovaResourceCard\NovaResourceCard;
 
 class Main extends Dashboard
 {
@@ -22,6 +23,10 @@ class Main extends Dashboard
      */
     public function cards()
     {
+        $loggedInUser = auth()->user();
+        $userId = $loggedInUser->id;
+        $url = url()->to('/');
+        $url .= '/resources/users/' . $userId . '/attach/projects?viaRelationship=projects&polymorphic=0';
         return [
 
 
@@ -60,9 +65,10 @@ class Main extends Dashboard
                 return $user->hasRole(UserRole::Admin) || $user->hasRole(UserRole::Editor);
             }),
 
-
-
-
+            (new NovaResourceCard('\App\Nova\FavoriteProjects'))
+                ->width('2/3')
+                ->setFooterLinkLabel(__('Attach projects to your favorites'))
+                ->setFooterLinkExternalUrl($url)
         ];
     }
 }

--- a/app/Nova/FavoriteProjects.php
+++ b/app/Nova/FavoriteProjects.php
@@ -159,7 +159,7 @@ class FavoriteProjects extends Resource
      */
     public function authorizedToDelete(Request $request): bool
     {
-        return true;
+        return false;
     }
 
     /**
@@ -170,7 +170,7 @@ class FavoriteProjects extends Resource
      */
     public function authorizedToRestore(Request $request): bool
     {
-        return true;
+        return false;
     }
 
     /**
@@ -192,7 +192,7 @@ class FavoriteProjects extends Resource
      */
     public function authorizedToForceDelete(Request $request): bool
     {
-        return true;
+        return false;
     }
 
     /**

--- a/app/Nova/FavoriteProjects.php
+++ b/app/Nova/FavoriteProjects.php
@@ -41,7 +41,7 @@ class FavoriteProjects extends Resource
      *
      * @return array
      */
-    public static $perPageOptions = [5];
+    public static $perPageOptions = [10];
 
     /**
      * Build an "index" query for the given resource.

--- a/app/Nova/FavoriteProjects.php
+++ b/app/Nova/FavoriteProjects.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace App\Nova;
+
+use App\Nova\Actions\RemoveFromFavoritesAction;
+use Laravel\Nova\Fields\ID;
+use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Date;
+use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class FavoriteProjects extends Resource
+{
+    /**
+     * The model the resource corresponds to.
+     *
+     * @var class-string<\App\Models\FavoriteProjects>
+     */
+    public static $model = \App\Models\Project::class;
+
+    /**
+     * Indicates if the resource should be globally searchable.
+     *
+     * @var bool
+     */
+    public static $globallySearchable = false;
+
+    /**
+     * Get the displayable label of the resource.
+     *
+     * @return string
+     */
+    public static function label(): string
+    {
+        return __('Favorite Projects');
+    }
+
+    /**
+     * The pagination per-page options configured for this resource.
+     *
+     * @return array
+     */
+    public static $perPageOptions = [5];
+
+    /**
+     * Build an "index" query for the given resource.
+     *
+     * @param NovaRequest $request
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+
+        $user = $request->user();
+
+        return $query->whereHas('users', function ($query) use ($user) {
+            $query->where('user_id', $user->id);
+        });
+    }
+
+
+    /**
+     * The single value that should be used to represent the resource when being displayed.
+     *
+     * @var string
+     */
+    public static $title = 'name';
+
+    /**
+     * The columns that should be searched.
+     *
+     * @var array
+     */
+    public static $search = [
+        'id', 'name'
+    ];
+
+    /**
+     * Get the fields displayed by the resource.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function fields(NovaRequest $request)
+    {
+        return [
+            ID::make()->sortable(),
+            Text::make('Name')
+                ->sortable()
+                ->rules('required', 'max:255'),
+            BelongsTo::make('Customer'),
+            //add a column to display the SAL of all epics in this milestone
+            Text::make('SAL', function () {
+                return $this->wip();
+            })->hideWhenCreating()->hideWhenUpdating(),
+            Text::make('Backlog', function () {
+                return $this->backlogStories()->count();
+            })->hideWhenCreating()->hideWhenUpdating(),
+            Date::make('Due date')->sortable(),
+        ];
+    }
+
+    /**
+     * Get the cards available for the request.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function cards(NovaRequest $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the filters available for the resource.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function filters(NovaRequest $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the lenses available for the resource.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function lenses(NovaRequest $request)
+    {
+        return [];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function actions(NovaRequest $request)
+    {
+        return [
+            (new RemoveFromFavoritesAction)
+                ->confirmButtonText('Remove')
+                ->cancelButtonText("Cancel")
+                ->onlyInline()
+        ];
+    }
+
+    /**
+     * Determine if the current user can delete the given resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizedToDelete(Request $request): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the current user can restore the given resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizedToRestore(Request $request): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the current user can update the given resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizedToUpdate(Request $request): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the current user can force delete the given resource.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizedToForceDelete(Request $request): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the current user can replicate the given resource or throw an exception.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizeToReplicate(Request $request): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine if the current user can attach any roles to the given resource or throw an exception.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    public function authorizeToAttachAny(Request $request): bool
+    {
+        return true;
+    }
+}

--- a/app/Nova/Project.php
+++ b/app/Nova/Project.php
@@ -146,7 +146,7 @@ class Project extends Resource
             (new RemoveFromFavoritesAction)
                 ->confirmButtonText('Remove')
                 ->cancelButtonText("Cancel")
-                ->onlyInline()
+                ->onlyInline(),
 
             (new addStoriesToBacklogAction)
                 ->onlyInline()

--- a/app/Nova/Project.php
+++ b/app/Nova/Project.php
@@ -14,6 +14,7 @@ use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\DateTime;
 use Eminiarts\Tabs\Traits\HasTabs;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\BelongsToMany;
 use Datomatic\NovaMarkdownTui\MarkdownTui;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Datomatic\NovaMarkdownTui\Enums\EditorType;
@@ -90,7 +91,7 @@ class Project extends Resource
                 new Tab('Backlog Stories', [
                     HasMany::make('Backlog Stories', 'backlogStories', Story::class),
                 ]),
-                BelongsToMany::make('Users', 'users', User::class),
+                BelongsToMany::make('Users'),
             ])
         ];
     }

--- a/app/Nova/Project.php
+++ b/app/Nova/Project.php
@@ -17,6 +17,7 @@ use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\BelongsToMany;
 use Datomatic\NovaMarkdownTui\MarkdownTui;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use App\Nova\Actions\RemoveFromFavoritesAction;
 use Datomatic\NovaMarkdownTui\Enums\EditorType;
 
 class Project extends Resource
@@ -139,7 +140,12 @@ class Project extends Resource
      */
     public function actions(NovaRequest $request)
     {
-        return [];
+        return [
+            (new RemoveFromFavoritesAction)
+                ->confirmButtonText('Remove')
+                ->cancelButtonText("Cancel")
+                ->onlyInline()
+        ];
     }
 
     public function indexBreadcrumb()

--- a/app/Nova/Project.php
+++ b/app/Nova/Project.php
@@ -91,7 +91,7 @@ class Project extends Resource
                 new Tab('Backlog Stories', [
                     HasMany::make('Backlog Stories', 'backlogStories', Story::class),
                 ]),
-                BelongsToMany::make('Users'),
+                BelongsToMany::make('Users', 'users'),
             ])
         ];
     }

--- a/app/Nova/Project.php
+++ b/app/Nova/Project.php
@@ -90,6 +90,7 @@ class Project extends Resource
                 new Tab('Backlog Stories', [
                     HasMany::make('Backlog Stories', 'backlogStories', Story::class),
                 ]),
+                BelongsToMany::make('Users', 'users', User::class),
             ])
         ];
     }

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -4,15 +4,16 @@ namespace App\Nova;
 
 use App\Enums\UserRole;
 use App\Models\Project;
-use Illuminate\Http\Request;
-use Illuminate\Validation\Rules;
-use Laravel\Nova\Fields\Gravatar;
-use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\ID;
-use Laravel\Nova\Fields\MultiSelect;
-use Laravel\Nova\Fields\Password;
-use Laravel\Nova\Fields\Select;
+use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Fields\Select;
+use Illuminate\Validation\Rules;
+use Laravel\Nova\Fields\HasMany;
+use Laravel\Nova\Fields\Gravatar;
+use Laravel\Nova\Fields\Password;
+use Laravel\Nova\Fields\MultiSelect;
+use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
 class User extends Resource
@@ -73,7 +74,7 @@ class User extends Resource
 
             HasMany::make('Epics'),
             HasMany::make('Stories'),
-            BelongsToMany::make('Projects', 'projects', Project::class),
+            BelongsToMany::make('Projects'),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -74,7 +74,7 @@ class User extends Resource
 
             HasMany::make('Epics'),
             HasMany::make('Stories'),
-            BelongsToMany::make('Projects'),
+            BelongsToMany::make('Projects', 'projects'),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -3,6 +3,7 @@
 namespace App\Nova;
 
 use App\Enums\UserRole;
+use App\Models\Project;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rules;
 use Laravel\Nova\Fields\Gravatar;
@@ -72,6 +73,7 @@ class User extends Resource
 
             HasMany::make('Epics'),
             HasMany::make('Stories'),
+            BelongsToMany::make('Projects', 'projects', Project::class),
         ];
     }
 

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -72,9 +72,9 @@ class User extends Resource
                 ->creationRules('required', Rules\Password::defaults())
                 ->updateRules('nullable', Rules\Password::defaults()),
 
+            BelongsToMany::make('Projects', 'projects'),
             HasMany::make('Epics'),
             HasMany::make('Stories'),
-            BelongsToMany::make('Projects', 'projects'),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "laravel/tinker": "^2.7",
         "league/flysystem-aws-s3-v3": "^3.12",
         "maatwebsite/excel": "^3.1",
+        "norman-huth/nova-resource-card": "^1.0",
         "outl1ne/nova-multiselect-field": "^4.2",
         "spatie/db-dumper": "^3.3",
         "spatie/laravel-translatable": "^6.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68ae0297b3f1741c2218ff1386bd2feb",
+    "content-hash": "b7039d9eca0f2fd923478c7829e463c9",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3873,6 +3873,58 @@
             "time": "2023-01-16T22:05:37+00:00"
         },
         {
+            "name": "norman-huth/nova-resource-card",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Muetze42/nova-resource-card.git",
+                "reference": "9446dc6026132c99bf1333e7a4792f9f5688c98b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Muetze42/nova-resource-card/zipball/9446dc6026132c99bf1333e7a4792f9f5688c98b",
+                "reference": "9446dc6026132c99bf1333e7a4792f9f5688c98b",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/nova": "^4.0",
+                "php": "^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "NormanHuth\\NovaResourceCard\\CardServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NormanHuth\\NovaResourceCard\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A Laravel Nova card.",
+            "keywords": [
+                "laravel",
+                "nova"
+            ],
+            "support": {
+                "issues": "https://github.com/Muetze42/nova-resource-card/issues",
+                "source": "https://github.com/Muetze42/nova-resource-card/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://huth.it/coffee",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-04-09T09:43:41+00:00"
+        },
+        {
             "name": "nova-kit/nova-packages-tool",
             "version": "v1.7.1",
             "source": {
@@ -5183,51 +5235,6 @@
                 }
             ],
             "time": "2023-02-09T15:13:18+00:00"
-        },
-        {
-            "name": "robertboes/nova-slider-field",
-            "version": "v0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/RobertBoes/nova-slider-field.git",
-                "reference": "a3f604d6d6758f1ad19331c95ee2d77bcc6006cb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/RobertBoes/nova-slider-field/zipball/a3f604d6d6758f1ad19331c95ee2d77bcc6006cb",
-                "reference": "a3f604d6d6758f1ad19331c95ee2d77bcc6006cb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Robertboes\\NovaSliderField\\FieldServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Robertboes\\NovaSliderField\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A Laravel Nova slider field.",
-            "keywords": [
-                "laravel",
-                "nova"
-            ],
-            "support": {
-                "issues": "https://github.com/RobertBoes/nova-slider-field/issues",
-                "source": "https://github.com/RobertBoes/nova-slider-field/tree/v0.1.1"
-            },
-            "time": "2020-03-22T11:27:49+00:00"
         },
         {
             "name": "spatie/db-dumper",
@@ -8048,7 +8055,7 @@
         },
         {
             "name": "wm/wm-internal",
-            "version": "dev-feature/app_conf_API_V1",
+            "version": "dev-feature/favorite_projects_with_external_package",
             "dist": {
                 "type": "path",
                 "url": "./wm-internal",

--- a/database/migrations/2023_06_08_092153_create_project_user_table.php
+++ b/database/migrations/2023_06_08_092153_create_project_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('project_user', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('project_id');
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('project_id')->references('id')->on('projects')->onDelete('cascade');
+
+            $table->primary(['user_id', 'project_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('project_user');
+    }
+};


### PR DESCRIPTION
Callback per filtrare user nel component del package non funziona, ho creato una risorsa speculare a Projects (FavoriteProjects) che visualizza soltanto i progetti relativi tramite una indexQuery (vedi new-epic, done-epic ecc..) e viene visualizzata solo nella card grazie alla proprietà : public static $globallySearchable = false;

Ho creato una action inline per poter togliere i progetti dai preferiti.

Ho utilizzato un metodo del component per creare un link che porta all'interfaccia di associazione dei project allo user. Funzionante, unico piccolo problema quando si è finita l'associazione riporta a pagina error 403 (le associazioni vanno comunque a buon fine). Testato sia come admin che come developer.