### PR TITLE
feat(nova): ✨ add DuplicateStory action to ArchivedStories OC: 5056

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Auth;
+use App\Nova\Actions\DuplicateStory;
 
 class Story extends Model implements HasMedia
 {

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -20,7 +20,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Auth;
-use App\Nova\Actions\DuplicateStory;
 
 class Story extends Model implements HasMedia
 {

--- a/app/Nova/Actions/DuplicateStory.php
+++ b/app/Nova/Actions/DuplicateStory.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Nova\Actions;
+
+use App\Models\Story;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class DuplicateStory extends Action
+{
+    use InteractsWithQueue, Queueable;
+
+    public $name = 'Duplicate Story';
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param  \Laravel\Nova\Fields\ActionFields  $fields
+     * @param  \Illuminate\Support\Collection  $models
+     * @return mixed
+     */
+    public function handle(ActionFields $fields, Collection $models)
+    {
+        foreach ($models as $story) {
+            $newStory = Story::create($story->toArray());
+            //createQuietly
+    
+            $newStory->status = StoryStatus::New->value;
+            // belongsTo
+            $newStory->developer()->associate($story->developer);
+            $newStory->creator()->associate($story->creator);
+            $newStory->tester()->associate($story->tester);
+            $newStory->project()->associate($story->project);
+            $newStory->epic()->associate($story->epic);
+            $newStory->parentStory()->associate($story->parentStory);
+            $newStory->user()->associate($story->user);
+    
+            // belongsToMany
+            $participantsIds = $story->participants->pluck('id')->toArray();
+            $newStory->participants()->sync($participantsIds);
+
+            $childStoryIds = $story->childStories->pluck('id')->toArray();
+            $newStory->childStories()->sync($childStoryIds);
+
+            $tagIds = $story->tags->pluck('id')->toArray();
+            $newStory->tags()->sync($tagIds);
+
+            $deadlinesIds = $story->deadlines->pluck('id')->toArray();
+            $newStory->deadlines()->sync($deadlinesIds);
+
+            $newStory->save();
+        }
+    
+        if ($models->count() === 1 && isset($newStory)) {
+            $resourceName = 'developer-stories';
+            $newModelId = $newStory->id;
+            $editUrl = url("/resources/{$resourceName}/{$newModelId}/edit");
+            return Action::openInNewTab($editUrl);
+        }
+        
+    }
+
+    /**
+     * Get the fields available on the action.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function fields(NovaRequest $request)
+    {
+        return [];
+    }
+}

--- a/app/Nova/ArchivedStories.php
+++ b/app/Nova/ArchivedStories.php
@@ -5,6 +5,7 @@ namespace App\Nova;
 use App\Enums\StoryStatus;
 use Illuminate\Http\Request;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use App\Nova\Actions\DuplicateStory;
 
 class ArchivedStories extends Story
 {
@@ -55,6 +56,13 @@ class ArchivedStories extends Story
             (new Metrics\StoriesByField('type', 'Type', $query))->width('1/3'),
             (new Metrics\StoriesByUser('creator_id', 'Customer', $query))->width('1/3'),
             (new Metrics\StoriesByUser('user_id', 'Assigned',  $query))->width('1/3'),
+        ];
+    }
+
+    public function actions(NovaRequest $request)
+    {
+        return [
+            (new DuplicateStory)->showInline()
         ];
     }
 }


### PR DESCRIPTION
- Introduced a new `DuplicateStory` action in the Nova `Actions` namespace.
- Implemented functionality to duplicate a story, associating related models and syncing relationships.
- Added the `DuplicateStory` action to the `ArchivedStories` Nova resource, enabling inline display for user actions.
- Enhanced model duplication process to maintain relationships like developer, creator, tester, project, epic, and related collections such as participants, child stories, tags, and deadlines.
- Ensured that the duplicated story opens in a new tab for single-item actions.