### PR TITLE
feat(Nova): ✨ add 'Estimate' field to Tag detail view OC:5727

### DIFF
--- a/app/Nova/Tag.php
+++ b/app/Nova/Tag.php
@@ -77,6 +77,10 @@ class Tag extends Resource
             MarkdownTui::make('Description')
                 ->hideFromIndex()
                 ->initialEditType(EditorType::MARKDOWN),
+            Number::make('Estimate', 'estimate')
+                ->min(0)
+                ->step(1)
+                ->onlyOnDetail(),
             MorphTo::make('Taggable')->types([
                 \App\Nova\Customer::class,
                 \App\Nova\App::class,


### PR DESCRIPTION
- Introduced a new Number field 'Estimate' in the Nova Tag resource.
- Configured the field to:
  - Accept only non-negative values.
  - Increment in steps of 1.
  - Be visible only on the detail view of the resource.