### PR TITLE
feat(tests): ✅ add TagSalTest for Tag resource in Nova OC: 5763

### DIFF
--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -28,6 +28,9 @@ class Tag extends Model
 
     public function getTotalHoursAttribute()
     {
+        if(!$this->tagged()->exists()) {
+            return null; // Se non ci sono storie associate
+        }
         return round($this->tagged()->sum('hours'), 2); // Somma delle ore delle storie associate arrotondata a due cifre
     }
 

--- a/app/Nova/Tag.php
+++ b/app/Nova/Tag.php
@@ -77,6 +77,10 @@ class Tag extends Resource
             MarkdownTui::make('Description')
                 ->hideFromIndex()
                 ->initialEditType(EditorType::MARKDOWN),
+            Number::make('Estimate', 'estimate')
+                ->min(0)
+                ->step(1)
+                ->onlyOnDetail(),
             MorphTo::make('Taggable')->types([
                 \App\Nova\Customer::class,
                 \App\Nova\App::class,

--- a/app/Nova/Tag.php
+++ b/app/Nova/Tag.php
@@ -58,20 +58,28 @@ class Tag extends Resource
                     1,  // Permette incrementi di 0.5 ore
                 )->onlyOnForms(),
             Text::make('Sal')->resolveUsing(function () {
-                $totalHours = $this->getTotalHoursAttribute(); // Calcola la somma delle ore
-                $estimate = $this->estimate; // Ottieni il valore stimato
+                $empty = __('Empty');
+                $totalHours = $this->getTotalHoursAttribute() ?? $empty; // Calcola la somma delle ore
+                $estimate = $this->estimate ?? $empty; // Ottieni il valore stimato
                 $color = $this->isClosed() ? 'green' : 'orange';
+                $salPercentage = $this->calculateSalPercentage();
+                $trend = $salPercentage >= 100 ? '😡' : '😊';
 
-                if ($totalHours && $estimate) {
-                    // Calcola la percentuale
-                    $salPercentage = $this->calculateSalPercentage();
+                if (!$this->getTotalHoursAttribute() && !$this->estimate) {
                     return  <<<HTML
-                    <a style="color:{$color}; font-weight:bold;"> {$totalHours} / $estimate </a> 
-                    <a style="color:{$color}; font-weight:bold;"> [{$salPercentage}%] </a>
+                        <a style="font-weight:bold;"> $empty </a> 
                     HTML;
                 }
+                if (!$this->getTotalHoursAttribute() || !$this->estimate) {
+                    return  <<<HTML
+                        <a style="font-weight:bold;"> $totalHours / $estimate </a> 
+                    HTML;
+                }
+
                 return  <<<HTML
-                <a style="color:{$color}; font-weight:bold;"> {$totalHours} / - </a> 
+                    $trend
+                    <a style="color:{$color}; font-weight:bold;"> $totalHours / $estimate </a> 
+                    <a style="color:{$color}; font-weight:bold;"> [$salPercentage%] </a>
                 HTML;
             })->asHtml()->onlyOnIndex(),
             MarkdownTui::make('Description')

--- a/lang/vendor/nova/en.json
+++ b/lang/vendor/nova/en.json
@@ -597,5 +597,6 @@
   "Payment plan": "Payment plan",
   "Delivery time": "Delivery time",
   "Costs": "Costs",
-  "Below we indicate the costs of the service divided into activation costs and annual maintenance costs": "Below we indicate the costs of the service divided into activation costs and annual maintenance costs"
+  "Below we indicate the costs of the service divided into activation costs and annual maintenance costs": "Below we indicate the costs of the service divided into activation costs and annual maintenance costs",
+  "Empty": "Empty"
 }

--- a/lang/vendor/nova/it.json
+++ b/lang/vendor/nova/it.json
@@ -396,5 +396,6 @@
   "Costs": "Costi",
   "Below we indicate the costs of the service divided into activation costs and annual maintenance costs": "Di seguito indichiamo i costi del servizio suddivisi in costi di attivazione e costi di manutenzione annuale",
   "actual": "attuale",
-  "estimated": "stimato"
+  "estimated": "stimato",
+  "Empty": "Vuoto"
 }

--- a/tests/Feature/TagSalTest.php
+++ b/tests/Feature/TagSalTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Tag;
+use App\Models\Story;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Tests\TestCase;
+
+class TagSalTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_sal_shows_empty_when_no_total_and_no_estimate()
+    {
+        $empty = __('Empty');
+        // Creo un tag con estimate = null
+        $tag = Tag::factory()->create(['estimate' => null,]);
+
+        // Assicurati che non ci siano ticket collegati a questo tag
+        $totalHours = $tag->getTotalHoursAttribute();
+        $this->assertTrue($totalHours === null || $totalHours === 0.0, "Total hours deve essere null o 0.0");
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+        // Istanzio la risorsa Nova associata al modello Tag
+        $tagResource = new \App\Nova\Tag($tag);
+        // Recupero tutti i campi visibili per questa richiesta
+        $tagFields = collect($tagResource->fields($tagRequest));
+        // Cerco il campo 'Sal' tra i campi visibili
+        $salField = $tagFields->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString(
+            "<a style=\"font-weight:bold;\"> {$empty} </a>",
+            $salHtml
+        );
+    }
+
+    public function test_sal_shows_total_hours_with_empty_estimate()
+    {
+        $empty = __('Empty');
+        $tag = Tag::factory()->create(['estimate' => null]);
+
+        $story1 = Story::factory()->create(['hours' => 15.00]);
+        $story2 = Story::factory()->create(['hours' => 20.87]);
+
+        $story1->tags()->attach($tag->id);
+        $story2->tags()->attach($tag->id);
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+
+        $tagResource = new \App\Nova\Tag($tag);
+        $tagFields = collect($tagResource->fields($tagRequest));
+
+        $salField = $tagFields->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString(
+            "<a style=\"font-weight:bold;\"> 35.87 / {$empty} </a>",
+            $salHtml
+        );
+    }
+
+    public function test_sal_shows_estimate_with_empty_total()
+    {
+        $empty = __('Empty');
+        $tag = Tag::factory()->create(['estimate' => 32]);
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+
+        $tagResource = new \App\Nova\Tag($tag);
+        $tagFields = collect($tagResource->fields($tagRequest));
+
+        $salField = $tagFields->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString(
+            "<a style=\"font-weight:bold;\"> {$empty} / 32 </a>",
+            $salHtml
+        );
+    }
+
+    public function test_sal_shows_total_and_estimate_with_percentage()
+    {
+        $tag = Tag::factory()->create(['estimate' => 48]);
+
+        $story1 = Story::factory()->create(['hours' => 20.75]);
+        $story2 = Story::factory()->create(['hours' => 20.00]);
+
+        $story1->tags()->attach($tag->id);
+        $story2->tags()->attach($tag->id);
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+        $tagResource = new \App\Nova\Tag($tag);
+        $tagFields = collect($tagResource->fields($tagRequest));
+
+        $salField = $tagFields->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString('😊', $salHtml);
+        $this->assertStringContainsString('<a style="color:orange; font-weight:bold;"> 40.75 / 48 </a>', $salHtml);
+        $this->assertStringContainsString('<a style="color:orange; font-weight:bold;"> [84.9%] </a>', $salHtml);
+    }
+
+    public function test_sal_shows_angry_trend_when_percentage_is_100_or_more()
+    {
+        $tag = Tag::factory()->create(['estimate' => 20]);
+
+        $story = Story::factory()->create(['hours' => 50]);
+        $story->tags()->attach($tag->id);
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+        $tagResource = new \App\Nova\Tag($tag);
+        $salField = collect($tagResource->fields($tagRequest))->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString('😡', $salHtml);
+    }
+
+    public function test_sal_shows_smile_trend_when_percentage_is_below_100()
+    {
+        $tag = Tag::factory()->create(['estimate' => 20]);
+
+        $story = Story::factory()->create(['hours' => 15]);
+        $story->tags()->attach($tag->id);
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+        $tagResource = new \App\Nova\Tag($tag);
+        $salField = collect($tagResource->fields($tagRequest))->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString('😊', $salHtml);
+    }
+
+    public function test_sal_shows_green_color_when_tag_is_closed()
+    {
+        $tag = Tag::factory()->create(['estimate' => 20]);
+
+        $story = Story::factory()->create(['hours' => 15, 'status' => 'done']);
+        $story->tags()->attach($tag->id);
+
+        // Verifica che il tag sia effettivamente chiuso
+        $this->assertTrue($tag->isClosed(), 'Il tag dovrebbe essere chiuso');
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+        $tagResource = new \App\Nova\Tag($tag);
+        $salField = collect($tagResource->fields($tagRequest))->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString('color:green', $salHtml);
+    }
+
+    public function test_sal_shows_orange_color_when_tag_is_open()
+    {
+        $tag = Tag::factory()->create(['estimate' => 20]);
+
+        $story = Story::factory()->create(['hours' => 15, 'status' => 'in_progress']);
+        $story->tags()->attach($tag->id);
+
+        $tagRequest = NovaRequest::create('/nova-api/tags', 'GET');
+        $tagResource = new \App\Nova\Tag($tag);
+        $salField = collect($tagResource->fields($tagRequest))->firstWhere('name', 'Sal');
+        $this->assertNotNull($salField, 'Campo Sal non trovato');
+
+        $salField->resolve($tag);
+        $salHtml = $salField->value;
+        $this->assertIsString($salHtml, 'Il campo Sal non restituisce una stringa');
+
+        $this->assertStringContainsString('color:orange', $salHtml);
+    }
+}


### PR DESCRIPTION
- Introduced a new test suite `TagSalTest` to ensure the correct functionality of the 'Sal' field in the Nova Tag resource.
- Implemented tests to cover various scenarios:
  - Displaying "Empty" when there are no total hours and no estimate.
  - Showing total hours with an empty estimate.
  - Showing estimate with empty total hours.
  - Displaying total and estimate with a percentage.
  - Showing angry trend when percentage is 100% or more.
  - Showing smile trend when percentage is below 100%.
  - Displaying green color when the tag is closed.
  - Displaying orange color when the tag is open.
- Utilized Laravel factories to generate necessary models for testing.
- Employed assertions to validate HTML output and ensure correct visual indicators are present.