### PR TITLE
feat(navigation): ✨ add external link for Google Meet OC: 5773

### DIFF
--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -59,6 +59,9 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                 MenuItem::externalLink('SCRUM', route('scrum.meeting', ['meetCode' => 'qcz-incv-dem']))->openInNewTab()->canSee(function ($request) {
                     return $request->user()->hasRole(UserRole::Admin) || $request->user()->hasRole(UserRole::Manager) || $request->user()->hasRole(UserRole::Developer);
                 }),
+                MenuItem::externalLink('MEET', 'https://meet.google.com/qcz-incv-dem')->openInNewTab()->canSee(function ($request) {
+                    return $request->user()->hasRole(UserRole::Admin) || $request->user()->hasRole(UserRole::Manager) || $request->user()->hasRole(UserRole::Developer);
+                }),
                 MenuSection::dashboard(Main::class)->icon('chart-bar')->canSee(function ($request) {
                     if ($request->user() == null)
                         return false;


### PR DESCRIPTION
- Introduced a new external menu item linking to Google Meet with code 'qcz-incv-dem'.
- Ensured the link opens in a new tab for roles: Admin, Manager, and Developer.
- Maintained existing roles visibility logic for consistency with other external links.