### PR TITLE
bug(story-viewer): ✨ open story in new tab on row click OC: 5881

### DIFF
--- a/resources/views/story-viewer.blade.php
+++ b/resources/views/story-viewer.blade.php
@@ -82,7 +82,7 @@
         </thead>
         <tbody>
             @forelse($stories as $story)
-                <tr onclick="window.location='{{ $urlNova . '/' . $story->id }}';" style="cursor: pointer;">
+                <tr onclick="window.open('{{ $urlNova . '/' . $story->id }}', '_blank');" style="cursor: pointer;">
                     <td>
                         <div class="text-500 font-bold" style="color:#2FBDA5;">{{ $story->id }}</div>
                     </td>


### PR DESCRIPTION
- Changed the behavior of the story table rows to open the story in a new browser tab when clicked.
- Updated the `onclick` event to use `window.open` with the `_blank` target, enhancing user experience by allowing them to keep the current page open while viewing the story in a separate tab.