### PR TITLE
feat(nova): ✨ add QuarterTagFilter for Tag resource OC: 5919

### DIFF
--- a/app/Nova/Filters/QuarterTagFilter.php
+++ b/app/Nova/Filters/QuarterTagFilter.php
@@ -53,7 +53,7 @@ class QuarterTagFilter extends Filter
 
             $label = "{$suffixYear}Q{$currentQuarter}";
             $quarters[$label] = $label;
-            $currentQuarter = $currentQuarter - 1;
+            $currentQuarter--;
         }
 
         return $quarters;

--- a/app/Nova/Filters/QuarterTagFilter.php
+++ b/app/Nova/Filters/QuarterTagFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Nova\Filters;
+
+use Laravel\Nova\Filters\Filter;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Carbon\Carbon;
+
+class QuarterTagFilter extends Filter
+{
+    /**
+     * The filter's component.
+     *
+     * @var string
+     */
+    public $component = 'select-filter';
+
+    /**
+     * Apply the filter to the given query.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function apply(NovaRequest $request, $query, $value)
+    {
+        return $query->where('name', 'like', "%{$value}%");
+    }
+
+    /**
+     * Get the filter's available options.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return array
+     */
+    public function options(NovaRequest $request)
+    {
+        $now = Carbon::now();
+        $currentYear = $now->year;
+        $suffixYear = substr((string)$currentYear, -2);
+        $currentQuarter = ceil($now->month / 3);
+
+        $quarters = [];
+
+        for ($i = 1; $i <= 4; $i++) {
+
+            if ($currentQuarter == 0) {
+                $currentQuarter = 4;
+                $currentYear--;
+                $suffixYear = substr((string)$currentYear, -2);
+            }
+
+            $label = "{$suffixYear}Q{$currentQuarter}";
+            $quarters[$label] = $label;
+            $currentQuarter = $currentQuarter - 1;
+        }
+
+        return $quarters;
+    }
+
+    public function name()
+    {
+        return __('Quarter Tag Filter');
+    }
+}

--- a/app/Nova/Tag.php
+++ b/app/Nova/Tag.php
@@ -12,6 +12,7 @@ use Datomatic\NovaMarkdownTui\MarkdownTui;
 use Laravel\Nova\Fields\MorphToMany;
 use Datomatic\NovaMarkdownTui\Enums\EditorType;
 use Laravel\Nova\Fields\Boolean;
+use App\Nova\Filters\QuarterTagFilter;
 
 class Tag extends Resource
 {
@@ -119,7 +120,9 @@ class Tag extends Resource
      */
     public function filters(Request $request)
     {
-        return [];
+        return [
+            new QuarterTagFilter,
+        ];
     }
 
     /**

--- a/tests/Feature/QuarterTagFilterTest.php
+++ b/tests/Feature/QuarterTagFilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Tag;
+use Illuminate\Support\Carbon;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use App\Nova\Filters\QuarterTagFilter;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class QuarterTagFilterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function test_it_returns_the_correct_quarter_options()
+    {
+        $now = Carbon::now();
+        $currentYear = $now->year;
+        $currentQuarter = (int) ceil($now->month / 3);
+        $expectedLabels = [];
+
+        for ($i = 1; $i <= 4; $i++) {
+            $suffixYear = substr((string) $currentYear, -2);
+            $expectedLabels[] = "{$suffixYear}Q{$currentQuarter}";
+
+            $currentQuarter--;
+            if ($currentQuarter == 0) {
+                $currentQuarter = 4;
+                $currentYear--;
+            }
+        }
+
+        $filter = new QuarterTagFilter();
+        $options = $filter->options(new NovaRequest());
+
+        $this->assertCount(4, $options);
+        $this->assertEquals($expectedLabels, array_keys($options));
+    }
+
+    public function test_it_returns_tags_matching_the_selected_quarter()
+    {
+        Tag::factory()->create(['name' => '[24Q4] Fixes']);
+        Tag::factory()->create(['name' => '[25Q3] Frontend']);
+        Tag::factory()->create(['name' => '[25Q32] Backend']);
+        Tag::factory()->create(['name' => '[25Q1] API']);
+        Tag::factory()->create(['name' => 'Database']);
+
+        $filter = new QuarterTagFilter();
+        $filtered = $filter->apply(NovaRequest::create('/', 'GET'), Tag::query(), '25Q3')->get();
+
+        $this->assertCount(2, $filtered);
+        foreach ($filtered as $tag) {
+            $this->assertStringContainsString('25Q3', $tag->name);
+        }
+    }
+
+    public function test_it_excludes_tags_without_quarter_pattern()
+    {
+        Tag::factory()->create(['name' => 'Random Tag']);
+        Tag::factory()->create(['name' => '[ABC] Tag']);
+        Tag::factory()->create(['name' => '[25Q4] Tag']);
+
+        $filter = new QuarterTagFilter();
+        $filtered = $filter->apply(NovaRequest::create('/', 'GET'), Tag::query(), '25Q3')->get();
+
+        $this->assertCount(0, $filtered);
+    }
+}


### PR DESCRIPTION
- Introduced a new `QuarterTagFilter` class to filter tags based on quarters.
- Implemented the filter logic to match tags with names containing the specified quarter.
- Added the filter to the `Tag` resource, enhancing the filtering capabilities in the Nova interface.
- Utilized Carbon to dynamically calculate and display the current and past four quarters as filter options.