### PR TITLE
chore(nova): hide holiday alert card OC 6135

### DIFF
--- a/app/Nova/Story.php
+++ b/app/Nova/Story.php
@@ -304,7 +304,9 @@ class Story extends Resource
             }),
             (new HtmlCard())->width('full')->withMeta([
                 'content' => $this->holidayAlert,
-            ])->center(true),
+            ])->center(true)->canSee(function ($request) {
+                return false;
+            }),
         ];
     }
 


### PR DESCRIPTION
Modifies the visibility condition for the holiday alert card in the user interface, preventing it from being displayed. This change addresses UI requirements and improves layout consistency.

Relates to issue #456