### PR TITLE
feat(quotes): ✨ add priority field to quotes model and sales dashboar…

### DIFF
--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -19,6 +19,7 @@ class Quote extends Model implements HasMedia
     protected $casts = [
         'additional_services' => 'array',
         'template' => 'bool',
+        'priority' => 'int',
     ];
 
     protected $fillable = [
@@ -26,6 +27,7 @@ class Quote extends Model implements HasMedia
         'title',
         'name',
         'status',
+        'priority',
         'additional_services',
         'customer_id',
         'google_drive_url',

--- a/app/Nova/Dashboards/Sales.php
+++ b/app/Nova/Dashboards/Sales.php
@@ -64,6 +64,8 @@ class Sales extends Dashboard
                     'customer.full_name' => __('Customer'),
                     'total' => __('Total'),
                 ])
+                ->priorityField('priority')
+                ->enableIntraColumnReorder(true)
                 ->limitPerColumn(5)
                 ->columns(
                     array_map(

--- a/database/migrations/2026_04_07_120000_add_priority_to_quotes_table.php
+++ b/database/migrations/2026_04_07_120000_add_priority_to_quotes_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->unsignedInteger('priority')->nullable()->after('status');
+            $table->index(['status', 'priority']);
+        });
+
+        // Backfill so existing quotes have a deterministic order per status.
+        $statuses = DB::table('quotes')
+            ->select('status')
+            ->distinct()
+            ->pluck('status');
+
+        foreach ($statuses as $status) {
+            $ids = DB::table('quotes')
+                ->where('status', $status)
+                ->orderBy('updated_at')
+                ->orderBy('id')
+                ->pluck('id');
+
+            foreach ($ids as $priority => $id) {
+                DB::table('quotes')
+                    ->where('id', $id)
+                    ->update(['priority' => $priority]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('quotes', function (Blueprint $table) {
+            $table->dropIndex(['status', 'priority']);
+            $table->dropColumn('priority');
+        });
+    }
+};
+


### PR DESCRIPTION
…d OC: 7542 (#204)

- Introduced a new integer field `priority` to the `Quote` model to manage sorting and prioritization.
- Updated the `Sales` dashboard to include a priority field and enabled intra-column reordering.
- Added a migration to handle the addition of the `priority` column to the `quotes` table, including backfilling existing data to ensure a consistent order based on `status`.
- Ensured the migration includes both `up` and `down` methods for adding and removing the `priority` column and its associated index.