### PR TITLE
feat(models, traits): ✨ restrict story type to helpdesk for customers OC:7543

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -161,7 +161,7 @@ class Story extends Model implements HasMedia
                 } elseif (!isset($story->tester_id)) {
                     $story->tester_id = $user->id;
                 }
-                if (!isset($story->type)) {
+                if ($user->hasRole(UserRole::Customer) && !isset($story->type)) {
                     $story->type = StoryType::Helpdesk->value;
                 }
 

--- a/app/Traits/fieldTrait.php
+++ b/app/Traits/fieldTrait.php
@@ -119,23 +119,33 @@ trait fieldTrait
     {
         $isEdit = $request->isCreateOrAttachRequest() || $request->isUpdateOrUpdateAttachedRequest();
         if ($isEdit) {
-            return  Select::make(__('Type'), $fieldName)
-                ->options(function () {
+            $isCustomer = $request->user()->hasRole(UserRole::Customer);
+
+            return Select::make(__('Type'), $fieldName)
+                ->options(function () use ($isCustomer) {
+                    if ($isCustomer) {
+                        return [
+                            StoryType::Helpdesk->value => StoryType::Helpdesk,
+                        ];
+                    }
+
                     return [
-                        StoryType::Feature->value =>  StoryType::Feature,
+                        StoryType::Feature->value => StoryType::Feature,
                         StoryType::Bug->value => StoryType::Bug,
                         StoryType::Helpdesk->value => StoryType::Helpdesk,
-                        StoryType::Scrum->value => StoryType::Scrum
+                        StoryType::Scrum->value => StoryType::Scrum,
                     ];
                 })
-                ->default(StoryType::Helpdesk->value)
-                ->help(__('Assign the type of the ticket.'))
-                ->readonly(function ($request) {
-                    return $this->type === StoryType::Scrum->value;
+                ->default(function () use ($isCustomer) {
+                    return $isCustomer ? StoryType::Helpdesk->value : null;
                 })
-                ->canSee(function ($request) {
-                    return  !$request->user()->hasRole(UserRole::Customer);
-                });
+                ->rules('required')
+                ->required()
+                ->help(__('Assign the type of the ticket.'))
+                ->readonly(function ($request) use ($isCustomer) {
+                    return $isCustomer || $this->type === StoryType::Scrum->value;
+                })
+                ->canSee($this->canSee($fieldName));
         } else {
             return Text::make(__('Type'), $fieldName, function () {
                 $color = 'green';


### PR DESCRIPTION
- Updated the Story model to automatically set the story type to Helpdesk if the user is a Customer and the type is not set.
- Modified the fieldTrait to restrict the available options for story types to Helpdesk when the user has a Customer role.
- Ensured that the default type is set to Helpdesk for customers during editing operations.
- Added a condition to make the type field readonly for customers or if the current type is Scrum.
- Updated the visibility logic of the type field to be determined by a separate `canSee` method for better customization.
