### PR TITLE
refactor(SelectedStoriesToExcel): ♻️ improve status mapping logic OC:7558

### DIFF
--- a/app/Exports/SelectedStoriesToExcel.php
+++ b/app/Exports/SelectedStoriesToExcel.php
@@ -46,7 +46,9 @@ class SelectedStoriesToExcel implements FromCollection, WithMapping, WithHeading
         $assignedTo = $story->developer?->name ?? '';
         $tester = $story->tester?->name ?? '';
 
-        $status = StoryStatus::tryFrom((string) $story->status)?->label() ?? (string) $story->status;
+        $status = $story->status instanceof StoryStatus
+            ? $story->status->label()
+            : StoryStatus::tryFrom((string) $story->status)?->label() ?? (string) $story->status;
         $createdAt = $story->created_at?->format('d/m/Y') ?? '';
 
         $request = $this->sanitizeRichText($story->customer_request ?? '');

--- a/tests/Feature/ExportStoriesToExcelActionTest.php
+++ b/tests/Feature/ExportStoriesToExcelActionTest.php
@@ -163,17 +163,8 @@ class ExportStoriesToExcelActionTest extends TestCase
         config(['app.url' => 'https://orchestrator.dev.maphub.it/']);
         $baseUrl = rtrim((string) config('app.url'), '/');
 
-        $story = new \App\Models\Story();
-        $story->id = 7525;
-        $story->status = 'todo';
-        $story->name = 'Test';
-        $story->customer_request = '<p>Hello</p>';
-        $story->setRelation('tags', collect());
-        $story->setRelation('creator', null);
-        $story->setRelation('developer', null);
-        $story->setRelation('tester', null);
-        $story->created_at = now();
 
+        $story = Story::factory()->create();
         $export = new SelectedStoriesToExcel(collect([$story]));
         $row = $export->map($story);
 


### PR DESCRIPTION
- Simplify the logic for determining a story's status by checking if the status is an instance of `StoryStatus` before attempting to use it.
- This ensures that the correct label is retrieved more efficiently, reducing potential errors and streamlining the code.

test(ExportStoriesToExcelAction): ✅ update test setup with factory

- Replace manual story creation in the test with a factory method to ensure consistency and leverage existing test setup utilities.
- This change enhances test reliability and reduces boilerplate code, making it easier to modify and extend test cases in the future.
