### PR TITLE
feat(kanban): ✨ introduce column aggregation and query application OC:7556

### DIFF
--- a/app/Nova/Dashboards/Sales.php
+++ b/app/Nova/Dashboards/Sales.php
@@ -9,6 +9,7 @@ use App\Models\Quote;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Laravel\Nova\Dashboard;
+use App\Nova\Kanban\SalesQuoteColumnAggregator;
 use Webmapp\KanbanCard\KanbanCard;
 
 class Sales extends Dashboard
@@ -44,10 +45,11 @@ class Sales extends Dashboard
         return [
             (new KanbanCard)
                 ->model(Quote::class, 'status')
-                ->with(['customer', 'user'])
+                ->with(['customer', 'user', 'products', 'recurringProducts'])
                 ->deniedToUpdateStatusForRoles([UserRole::Editor, UserRole::Developer])
                 ->allowedToUpdateStatusForRoles([UserRole::Admin, UserRole::Manager])
                 ->resourceUri('quotes')
+                ->aggregateColumnsUsing(SalesQuoteColumnAggregator::class)
                 ->filterAndSearchBy(
                     'customer_id',
                     Customer::class,

--- a/app/Nova/Kanban/SalesQuoteColumnAggregator.php
+++ b/app/Nova/Kanban/SalesQuoteColumnAggregator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Nova\Kanban;
+
+use App\Models\Quote;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Webmapp\KanbanCard\Contracts\AggregatesKanbanColumn;
+
+class SalesQuoteColumnAggregator implements AggregatesKanbanColumn
+{
+    /**
+     * Aggregate Sales Kanban columns:
+     * - count: number of quotes in the column
+     * - sum: total economic value of quotes in the column
+     */
+    public function aggregate(Collection $items, Request $request, string $statusValue, array $config)
+    {
+        $sum = (float) $items->sum(function ($item) {
+            if (! $item instanceof Quote) {
+                return 0.0;
+            }
+
+            // Numeric total (not the formatted accessor string).
+            return $item->getTotalPrice()
+                + $item->getTotalRecurringPrice()
+                + $item->getTotalAdditionalServicesPrice();
+        });
+
+        return [
+            'count' => (int) $items->count(),
+            'sum' => $sum,
+        ];
+    }
+}
+

--- a/nova-components/kanban-card/dist/css/card.css
+++ b/nova-components/kanban-card/dist/css/card.css
@@ -381,6 +381,27 @@
     color: #d1d5db;
 }
 
+.kanban-column-title-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+}
+
+.kanban-column-sum {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #111827;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 16rem;
+}
+
+.dark .kanban-column-sum {
+    color: #f3f4f6;
+}
+
 .kanban-column-count {
     font-size: 0.6875rem;
     font-weight: 700;

--- a/nova-components/kanban-card/dist/js/card.js
+++ b/nova-components/kanban-card/dist/js/card.js
@@ -84,9 +84,14 @@ Nova.booting((app) => {
                     >
                         <!-- Column Header -->
                         <div class="kanban-column-header kanban-column-header-clickable" @click.stop="toggleColumnCollapsed(column.value)">
-                            <span class="kanban-column-title">{{ column.label }}</span>
+                            <div class="kanban-column-title-wrap">
+                                <span class="kanban-column-title">{{ column.label }}</span>
+                                <span v-if="getHeaderSum(column.value) !== null" class="kanban-column-sum">
+                                    {{ formatCurrency(getHeaderSum(column.value)) }}
+                                </span>
+                            </div>
                             <span class="kanban-column-count" :style="{ backgroundColor: column.color }">
-                                {{ totalCountByStatus[column.value] !== undefined ? totalCountByStatus[column.value] : getColumnItems(column.value).length }}
+                                {{ getHeaderCount(column.value) }}
                             </span>
                         </div>
 
@@ -384,7 +389,9 @@ Nova.booting((app) => {
                 var localCount = this.getColumnItems(status).length;
                 if (localCount > 0) return false;
                 if (this.totalCountByStatus && this.totalCountByStatus[status] !== undefined) {
-                    return Number(this.totalCountByStatus[status]) === 0;
+                    var v = this.totalCountByStatus[status];
+                    if (v && typeof v === 'object' && v.count !== undefined) return Number(v.count) === 0;
+                    return Number(v) === 0;
                 }
                 return true;
             },
@@ -673,6 +680,40 @@ Nova.booting((app) => {
                     next[col.value] = count >= limit;
                 });
                 self.hasMoreByStatus = next;
+            },
+
+            /**
+             * Returns the real total count for a column when available.
+             * Supports both legacy numeric responses and extended {count, sum} objects.
+             */
+            getHeaderCount(status) {
+                var v = this.totalCountByStatus ? this.totalCountByStatus[status] : undefined;
+                if (v && typeof v === 'object' && v.count !== undefined) return v.count;
+                if (v !== undefined) return v;
+                return this.getColumnItems(status).length;
+            },
+
+            /**
+             * Returns the sum value for a column when provided by backend.
+             */
+            getHeaderSum(status) {
+                var v = this.totalCountByStatus ? this.totalCountByStatus[status] : undefined;
+                if (v && typeof v === 'object' && v.sum !== undefined && v.sum !== null) {
+                    var n = Number(v.sum);
+                    return isNaN(n) ? null : n;
+                }
+                return null;
+            },
+
+            /**
+             * Formats a number as EUR currency (Italian formatting).
+             */
+            formatCurrency(amount) {
+                try {
+                    return new Intl.NumberFormat('it-IT', { style: 'currency', currency: 'EUR' }).format(Number(amount) || 0);
+                } catch (e) {
+                    return '€ ' + String(amount);
+                }
             },
 
             /**

--- a/nova-components/kanban-card/src/Contracts/AggregatesKanbanColumn.php
+++ b/nova-components/kanban-card/src/Contracts/AggregatesKanbanColumn.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webmapp\KanbanCard\Contracts;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+
+interface AggregatesKanbanColumn
+{
+    /**
+     * Aggregate all items of a single column.
+     *
+     * @param  Collection<int,object>  $items  All models retrieved for the column.
+     * @param  Request  $request
+     * @param  string  $statusValue  The requested column status (virtual statuses included).
+     * @param  array  $config  Full card config sent by the frontend.
+     * @return mixed
+     */
+    public function aggregate(Collection $items, Request $request, string $statusValue, array $config);
+}
+

--- a/nova-components/kanban-card/src/Contracts/AppliesKanbanQuery.php
+++ b/nova-components/kanban-card/src/Contracts/AppliesKanbanQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Webmapp\KanbanCard\Contracts;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+
+interface AppliesKanbanQuery
+{
+    /**
+     * Apply additional constraints to the Kanban base query.
+     *
+     * @param  Builder  $query  Base query already scoped/filtered/searched (status still applied by controller).
+     * @param  Request  $request
+     * @param  string|null  $statusValue  The status currently being loaded (virtual statuses included).
+     * @param  array  $config  Full card config sent by the frontend.
+     * @return Builder
+     */
+    public function apply(Builder $query, Request $request, ?string $statusValue, array $config): Builder;
+}
+

--- a/nova-components/kanban-card/src/Http/Controllers/KanbanController.php
+++ b/nova-components/kanban-card/src/Http/Controllers/KanbanController.php
@@ -8,6 +8,8 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Webmapp\KanbanCard\Contracts\AggregatesKanbanColumn;
+use Webmapp\KanbanCard\Contracts\AppliesKanbanQuery;
 
 class KanbanController extends Controller
 {
@@ -100,7 +102,7 @@ class KanbanController extends Controller
 
         // Load more: single column, offset + limit
         if ($singleStatus !== null && $singleStatus !== '') {
-            $query = $this->buildItemsQuery($modelClass, $withRelations, $filterField, $allowedFilterFields, $searchFields, $scopeName, $request, (string) $singleStatus, $statusFilterOverrides, $excludedFieldValues);
+            $query = $this->buildItemsQuery($modelClass, $withRelations, $filterField, $allowedFilterFields, $searchFields, $scopeName, $request, (string) $singleStatus, $statusFilterOverrides, $excludedFieldValues, $config);
             if ($this->isTestedByOthersColumn((string) $singleStatus)) {
                 $query->where($statusField, 'tested');
                 $this->applyTestedByOthersConstraint($query, $request);
@@ -137,7 +139,7 @@ class KanbanController extends Controller
         // Initial load: up to limitPerColumn per status
         $allItems = [];
         foreach ($statusValues as $statusValue) {
-            $query = $this->buildItemsQuery($modelClass, $withRelations, $filterField, $allowedFilterFields, $searchFields, $scopeName, $request, (string) $statusValue, $statusFilterOverrides, $excludedFieldValues);
+            $query = $this->buildItemsQuery($modelClass, $withRelations, $filterField, $allowedFilterFields, $searchFields, $scopeName, $request, (string) $statusValue, $statusFilterOverrides, $excludedFieldValues, $config);
             if ($this->isTestedByOthersColumn((string) $statusValue)) {
                 $query->where($statusField, 'tested');
                 $this->applyTestedByOthersConstraint($query, $request);
@@ -196,16 +198,22 @@ class KanbanController extends Controller
         $statuses = $request->input('statuses');
         $statusValues = $statuses ? (is_string($statuses) ? explode(',', $statuses) : $statuses) : [];
 
+        $aggregator = $this->resolveColumnAggregator($config);
         $counts = [];
         foreach ($statusValues as $statusValue) {
-            $query = $this->buildItemsQuery($modelClass, $withRelations, $filterField, $allowedFilterFields, $searchFields, $scopeName, $request, (string) $statusValue, $statusFilterOverrides, $excludedFieldValues);
+            $query = $this->buildItemsQuery($modelClass, $withRelations, $filterField, $allowedFilterFields, $searchFields, $scopeName, $request, (string) $statusValue, $statusFilterOverrides, $excludedFieldValues, $config);
             if ($this->isTestedByOthersColumn((string) $statusValue)) {
                 $query->where($statusField, 'tested');
                 $this->applyTestedByOthersConstraint($query, $request);
             } else {
                 $query->where($statusField, $statusValue);
             }
-            $counts[(string) $statusValue] = $query->count();
+            if ($aggregator !== null) {
+                $items = $query->get();
+                $counts[(string) $statusValue] = $aggregator->aggregate($items, $request, (string) $statusValue, $config);
+            } else {
+                $counts[(string) $statusValue] = $query->count();
+            }
         }
 
         return response()->json($counts);
@@ -224,7 +232,8 @@ class KanbanController extends Controller
         Request $request,
         ?string $statusValue = null,
         array $statusFilterOverrides = [],
-        array $excludedFieldValues = []
+        array $excludedFieldValues = [],
+        ?array $config = null
     ) {
         $query = $modelClass::query();
 
@@ -313,7 +322,57 @@ class KanbanController extends Controller
             });
         }
 
+        $resolvedConfig = $config ?? ($this->getConfigFromRequest($request) ?? []);
+        $queryApplier = $this->resolveQueryApplier($resolvedConfig);
+        if ($queryApplier !== null) {
+            $query = $queryApplier->apply($query, $request, $statusValue, $resolvedConfig);
+        }
+
         return $query;
+    }
+
+    /**
+     * Resolve query applier from card config (if any).
+     */
+    protected function resolveQueryApplier(array $config): ?AppliesKanbanQuery
+    {
+        $class = $config['queryApplierClass'] ?? null;
+        if (!is_string($class) || $class === '' || ! class_exists($class)) {
+            return null;
+        }
+        if (!is_subclass_of($class, AppliesKanbanQuery::class)) {
+            return null;
+        }
+
+        try {
+            $instance = app($class);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        return $instance instanceof AppliesKanbanQuery ? $instance : null;
+    }
+
+    /**
+     * Resolve column aggregator from card config (if any).
+     */
+    protected function resolveColumnAggregator(array $config): ?AggregatesKanbanColumn
+    {
+        $class = $config['columnAggregatorClass'] ?? null;
+        if (!is_string($class) || $class === '' || ! class_exists($class)) {
+            return null;
+        }
+        if (!is_subclass_of($class, AggregatesKanbanColumn::class)) {
+            return null;
+        }
+
+        try {
+            $instance = app($class);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        return $instance instanceof AggregatesKanbanColumn ? $instance : null;
     }
 
     /**

--- a/nova-components/kanban-card/src/KanbanCard.php
+++ b/nova-components/kanban-card/src/KanbanCard.php
@@ -4,6 +4,8 @@ namespace Webmapp\KanbanCard;
 
 use Illuminate\Support\Str;
 use Laravel\Nova\Card;
+use Webmapp\KanbanCard\Contracts\AggregatesKanbanColumn;
+use Webmapp\KanbanCard\Contracts\AppliesKanbanQuery;
 
 class KanbanCard extends Card
 {
@@ -115,6 +117,18 @@ class KanbanCard extends Card
      * Optional scope/filter closure key.
      */
     public ?string $scopeName = null;
+
+    /**
+     * Optional query applier class to further constrain the base query (server-side).
+     * Must implement AppliesKanbanQuery.
+     */
+    public ?string $queryApplierClass = null;
+
+    /**
+     * Optional per-column aggregator class (server-side).
+     * If set, controller counts() will load all items of each column and call it.
+     */
+    public ?string $columnAggregatorClass = null;
 
     /**
      * Optional per-status filter field overrides.
@@ -322,6 +336,35 @@ class KanbanCard extends Card
     public function scope(string $name): self
     {
         $this->scopeName = $name;
+
+        return $this;
+    }
+
+    /**
+     * Apply additional constraints using a dedicated class (instead of a non-serializable closure).
+     *
+     * Example:
+     *   ->applyQueryUsing(\App\Nova\Kanban\MyStoriesKanbanQuery::class)
+     *
+     * @param  class-string<AppliesKanbanQuery>  $class
+     */
+    public function applyQueryUsing(string $class): self
+    {
+        $this->queryApplierClass = $class !== '' ? $class : null;
+
+        return $this;
+    }
+
+    /**
+     * Aggregate each column using a dedicated class (instead of a non-serializable closure).
+     *
+     * The controller will load all items for each column (unpaginated) and pass them to the aggregator.
+     *
+     * @param  class-string<AggregatesKanbanColumn>  $class
+     */
+    public function aggregateColumnsUsing(string $class): self
+    {
+        $this->columnAggregatorClass = $class !== '' ? $class : null;
 
         return $this;
     }
@@ -656,6 +699,8 @@ class KanbanCard extends Card
             'deniedUpdateRoles' => $this->deniedUpdateRoles,
             'allowedUpdateRoles' => $this->allowedUpdateRoles,
             'scopeName' => $this->scopeName,
+            'queryApplierClass' => $this->queryApplierClass,
+            'columnAggregatorClass' => $this->columnAggregatorClass,
             'statusFilterOverrides' => $this->statusFilterOverrides,
             'statusColumnLimits' => $this->statusColumnLimits,
             'selectOnly' => $this->selectOnly,


### PR DESCRIPTION
- Added `SalesQuoteColumnAggregator` to aggregate sales kanban columns by count and sum of economic value.
- Updated `KanbanCard` to support column aggregation and additional query constraints using dedicated classes.
- Modified `KanbanController` to resolve and apply column aggregators and query appliers based on card configuration.
- Enhanced frontend to display aggregated sum in kanban column headers.
- Introduced styling for new sum display and improved column header layout for better readability.
- Implemented contracts `AggregatesKanbanColumn` and `AppliesKanbanQuery` to standardize the aggregation and query application logic.
