### PR TITLE
refactor(pricing): ♻️ simplify total price calculation OC:7675 (#214)

### DIFF
--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -147,6 +147,16 @@ class Quote extends Model implements HasMedia
 
         return number_format($total, 2, ',', '.') . ' €';
     }
+    
+    /**
+     * Accessor for display (e.g. Kanban card): net total price formatted.
+     */
+    public function getNetTotalAttribute(): string
+    {
+        $total = $this->getQuoteNetPrice();
+
+        return number_format($total, 2, ',', '.') . ' €';
+    }
 
     public function registerMediaCollections(): void
     {

--- a/app/Nova/Dashboards/Sales.php
+++ b/app/Nova/Dashboards/Sales.php
@@ -64,7 +64,7 @@ class Sales extends Dashboard
                 ->subtitle('customer.full_name')
                 ->displayFields([
                     'customer.full_name' => __('Customer'),
-                    'total' => __('Total'),
+                    'net_total' => __('Total'),
                 ])
                 ->priorityField('priority')
                 ->enableIntraColumnReorder(true)

--- a/app/Nova/Kanban/SalesQuoteColumnAggregator.php
+++ b/app/Nova/Kanban/SalesQuoteColumnAggregator.php
@@ -21,10 +21,8 @@ class SalesQuoteColumnAggregator implements AggregatesKanbanColumn
                 return 0.0;
             }
 
-            // Numeric total (not the formatted accessor string).
-            return $item->getTotalPrice()
-                + $item->getTotalRecurringPrice()
-                + $item->getTotalAdditionalServicesPrice();
+            // Use net quote price so column totals include any discount.
+            return $item->getQuoteNetPrice();
         });
 
         return [

--- a/tests/Feature/QuoteTotalsAttributesTest.php
+++ b/tests/Feature/QuoteTotalsAttributesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\Quote;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class QuoteTotalsAttributesTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_exposes_gross_total_via_total_attribute_and_net_total_via_net_total_attribute()
+    {
+        Customer::factory()->create();
+
+        $product = Product::factory()->create(['price' => 100]);
+
+        $quote = Quote::factory()->create([
+            'additional_services' => [
+                'en' => [
+                    'service1' => 50,
+                ],
+            ],
+            'discount' => 20,
+        ]);
+
+        $quote->products()->attach([$product->id => ['quantity' => 1]]);
+
+        // Gross total (no discount): 100 + 50 = 150
+        $this->assertSame('150,00 €', $quote->total);
+
+        // Net total (discount applied): 150 - 20 = 130
+        $this->assertSame('130,00 €', $quote->net_total);
+    }
+}
+

--- a/tests/Feature/SalesQuoteColumnAggregatorTest.php
+++ b/tests/Feature/SalesQuoteColumnAggregatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\Quote;
+use App\Nova\Kanban\SalesQuoteColumnAggregator;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class SalesQuoteColumnAggregatorTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_sums_net_quote_prices_and_counts_all_items()
+    {
+        Customer::factory()->create();
+
+        $product = Product::factory()->create(['price' => 100]);
+
+        $quoteA = Quote::factory()->create([
+            'additional_services' => null,
+            'discount' => 10,
+        ]);
+        $quoteA->products()->attach([$product->id => ['quantity' => 1]]);
+        $this->assertSame(90.0, $quoteA->getQuoteNetPrice());
+
+        $quoteB = Quote::factory()->create([
+            'additional_services' => [
+                'en' => ['s1' => 50],
+            ],
+            'discount' => 0,
+        ]);
+        $quoteB->products()->attach([$product->id => ['quantity' => 2]]);
+        $this->assertSame(250.0, $quoteB->getQuoteNetPrice());
+
+        $items = new Collection([$quoteA, $quoteB, 'not-a-quote']);
+
+        $result = (new SalesQuoteColumnAggregator())->aggregate(
+            $items,
+            Request::create('/'),
+            'any',
+            []
+        );
+
+        // Count is the number of items in the column, regardless of type.
+        $this->assertSame(3, $result['count']);
+
+        // Sum uses only Quote items and uses net price (discount applied).
+        $this->assertSame(340.0, $result['sum']);
+    }
+}


### PR DESCRIPTION
* refactor(pricing): ♻️ simplify total price calculation OC:7675

- Updated `getTotalAttribute` in `Quote.php` to use `getQuoteNetPrice()` for calculating the total, ensuring consistency.
- Modified `SalesQuoteColumnAggregator.php` to use `getQuoteNetPrice()` for aggregating column totals, incorporating any discounts directly.
- Streamlined pricing logic to eliminate repetitive calls and potential discrepancies in total calculations.

* feat(models): ✨ add formatted total and net total attributes OC:7675

- Implemented `getTotalAttribute` and `getNetTotalAttribute` methods in the `Quote` model to provide formatted total and net total prices.
- Updated the `Sales` dashboard to display the net total instead of the gross total.

test(feature): 🧪 add tests for Quote total attributes and SalesQuoteColumnAggregator

- Created `QuoteTotalsAttributesTest` to ensure gross and net totals are correctly exposed via respective attributes.
- Developed `SalesQuoteColumnAggregatorTest` to verify correct summation of net quote prices and item counting.
- Utilized `DatabaseTransactions` for test consistency and isolation.