### PR TITLE
feat(metrics): ✨ add TagHoursTotal metric to display estimated and effective hours OC:7705

### DIFF
--- a/app/Nova/Metrics/TagHoursTotal.php
+++ b/app/Nova/Metrics/TagHoursTotal.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Nova\Metrics;
+
+use App\Models\Tag;
+use InvalidArgumentException;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Metrics\Value;
+
+class TagHoursTotal extends Value
+{
+    public function __construct(
+        private readonly string $mode
+    ) {
+        if (!in_array($mode, ['estimated', 'effective'], true)) {
+            throw new InvalidArgumentException(sprintf('Invalid TagHoursTotal mode: %s', $mode));
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    public function calculate(NovaRequest $request)
+    {
+        $tag = $request->findModel();
+
+        if (! $tag instanceof Tag) {
+            return $this->hoursResult(0.0);
+        }
+
+        $total = match ($this->mode) {
+            'estimated' => round((float) ($tag->estimate ?? 0), 2),
+            'effective' => (float) ($tag->getTotalHoursAttribute() ?? 0),
+        };
+
+        return $this->hoursResult($total);
+    }
+
+    public function uriKey()
+    {
+        return match ($this->mode) {
+            'estimated' => 'tag-estimated-hours-total',
+            'effective' => 'tag-effective-hours-total',
+        };
+    }
+
+    public function name()
+    {
+        return match ($this->mode) {
+            'estimated' => __('Total Estimated Hours'),
+            'effective' => __('Total Effective Hours'),
+        };
+    }
+
+    private function hoursResult(float $value)
+    {
+        return $this->precision(2)->result($value)->suffix(__('h'))->allowZeroResult();
+    }
+}

--- a/app/Nova/Tag.php
+++ b/app/Nova/Tag.php
@@ -7,12 +7,12 @@ use Illuminate\Http\Request;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\MorphTo;
+use App\Nova\Metrics\TagHoursTotal;
 use App\Nova\Metrics\TagSal;
+use App\Nova\Filters\QuarterTagFilter;
+use Datomatic\NovaMarkdownTui\Enums\EditorType;
 use Datomatic\NovaMarkdownTui\MarkdownTui;
 use Laravel\Nova\Fields\MorphToMany;
-use Datomatic\NovaMarkdownTui\Enums\EditorType;
-use Laravel\Nova\Fields\Boolean;
-use App\Nova\Filters\QuarterTagFilter;
 
 class Tag extends Resource
 {
@@ -108,7 +108,9 @@ class Tag extends Resource
     public function cards(Request $request)
     {
         return [
-            (new TagSal())->onlyOnDetail()
+            (new TagHoursTotal('estimated'))->onlyOnDetail(),
+            (new TagHoursTotal('effective'))->onlyOnDetail(),
+            (new TagSal())->onlyOnDetail(),
         ];
     }
 

--- a/lang/vendor/nova/en.json
+++ b/lang/vendor/nova/en.json
@@ -732,5 +732,7 @@
   "Sales Kanban View": "Sales Kanban View",
   "Search or select customer:": "Search or select customer:",
   "Kanban View": "Kanban View",
-  "View kanban for:": "View kanban for:"
+  "View kanban for:": "View kanban for:",
+  "Total Estimated Hours": "Total Estimated Hours",
+  "Total Effective Hours": "Total Effective Hours"
 }

--- a/lang/vendor/nova/it.json
+++ b/lang/vendor/nova/it.json
@@ -520,5 +520,7 @@
   "Sales Kanban View": "Visualizza Kanban Commerciale",
   "Search or select customer:": "Cerca o seleziona cliente:",
   "Kanban View": "Vista Kanban",
-  "View kanban for:": "Visualizza kanban per:"
+  "View kanban for:": "Visualizza kanban per:",
+  "Total Estimated Hours": "Totale Ore Stimate",
+  "Total Effective Hours": "Totale Ore Effettive"
 }

--- a/nova-components/kanban-card/src/Http/Controllers/KanbanController.php
+++ b/nova-components/kanban-card/src/Http/Controllers/KanbanController.php
@@ -4,6 +4,7 @@ namespace Webmapp\KanbanCard\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -513,12 +514,14 @@ class KanbanController extends Controller
         $validSet = array_fill_keys($validIds, true);
         $orderedValidIds = array_values(array_filter($ids, fn ($id) => isset($validSet[$id])));
 
-        DB::transaction(function () use ($modelClass, $keyName, $priorityField, $orderedValidIds) {
-            foreach ($orderedValidIds as $priority => $itemId) {
-                $modelClass::query()
-                    ->where($keyName, $itemId)
-                    ->update([$priorityField => $priority]);
-            }
+        Model::withoutTimestamps(function () use ($modelClass, $keyName, $priorityField, $orderedValidIds) {
+            DB::transaction(function () use ($modelClass, $keyName, $priorityField, $orderedValidIds) {
+                foreach ($orderedValidIds as $priority => $itemId) {
+                    $modelClass::query()
+                        ->where($keyName, $itemId)
+                        ->update([$priorityField => $priority]);
+                }
+            });
         });
 
         return response()->json(['success' => true]);

--- a/tests/Feature/TagHoursMetricsTest.php
+++ b/tests/Feature/TagHoursMetricsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Story;
+use App\Models\Tag;
+use App\Nova\Metrics\TagHoursTotal;
+use App\Nova\Tag as TagNovaResource;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Mockery;
+use Tests\TestCase;
+
+class TagHoursMetricsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * NovaRequest come sulla detail metric (findModel → Tag). Mock evita routing Nova nei test.
+     */
+    private function novaDetailMetricRequest(Tag $tag): NovaRequest
+    {
+        $request = Mockery::mock(NovaRequest::class);
+        $request->shouldReceive('findModel')->once()->withAnyArgs()->andReturn($tag);
+
+        return $request;
+    }
+
+    public function test_estimated_hours_metric_uses_tag_estimate_like_sal_card(): void
+    {
+        $tag = Tag::factory()->create(['estimate' => 999.0]);
+        $s1 = Story::factory()->create(['estimated_hours' => 2.5, 'hours' => 1.0]);
+        $s2 = Story::factory()->create(['estimated_hours' => 3.5, 'hours' => 1.0]);
+        $s1->tags()->attach($tag->id);
+        $s2->tags()->attach($tag->id);
+
+        $result = (new TagHoursTotal('estimated'))->calculate($this->novaDetailMetricRequest($tag));
+
+        $this->assertEqualsWithDelta(999.0, (float) $result->value, 0.001);
+    }
+
+    public function test_estimated_hours_metric_uses_tag_estimate_even_when_stories_have_null_estimated_hours(): void
+    {
+        $tag = Tag::factory()->create(['estimate' => 8.0]);
+        $story = Story::factory()->create(['estimated_hours' => null, 'hours' => 10.0]);
+        $story->tags()->attach($tag->id);
+
+        $result = (new TagHoursTotal('estimated'))->calculate($this->novaDetailMetricRequest($tag));
+
+        $this->assertEqualsWithDelta(8.0, (float) $result->value, 0.001);
+    }
+
+    public function test_effective_hours_metric_is_zero_when_tag_has_no_stories(): void
+    {
+        $tag = Tag::factory()->create();
+        $this->assertFalse($tag->tagged()->exists(), 'Tag should have no linked stories');
+
+        $result = (new TagHoursTotal('effective'))->calculate($this->novaDetailMetricRequest($tag));
+
+        $this->assertEqualsWithDelta(0.0, (float) $result->value, 0.001);
+    }
+
+    public function test_effective_hours_metric_sums_story_hours(): void
+    {
+        $tag = Tag::factory()->create();
+        $s1 = Story::factory()->create(['hours' => 10.25, 'estimated_hours' => null]);
+        $s2 = Story::factory()->create(['hours' => 5.5, 'estimated_hours' => null]);
+        $s1->tags()->attach($tag->id);
+        $s2->tags()->attach($tag->id);
+
+        $result = (new TagHoursTotal('effective'))->calculate($this->novaDetailMetricRequest($tag));
+
+        $this->assertEqualsWithDelta(15.75, (float) $result->value, 0.001);
+    }
+
+    public function test_effective_hours_metric_returns_zero_when_no_story_hours(): void
+    {
+        $tag = Tag::factory()->create();
+        $story = Story::factory()->create(['hours' => null]);
+        $story->tags()->attach($tag->id);
+
+        $result = (new TagHoursTotal('effective'))->calculate($this->novaDetailMetricRequest($tag));
+
+        $this->assertEqualsWithDelta(0.0, (float) $result->value, 0.001);
+    }
+
+    public function test_nova_tag_resource_includes_hours_metrics_on_detail(): void
+    {
+        $request = NovaRequest::create('/nova-api/tags/1', 'GET');
+        $cards = (new TagNovaResource(Tag::factory()->make()))->cards($request);
+
+        $hoursCards = array_values(array_filter($cards, fn ($card) => $card instanceof TagHoursTotal));
+        $this->assertCount(2, $hoursCards);
+
+        $uriKeys = array_map(fn (TagHoursTotal $card) => $card->uriKey(), $hoursCards);
+        sort($uriKeys);
+
+        $this->assertSame(
+            ['tag-effective-hours-total', 'tag-estimated-hours-total'],
+            $uriKeys
+        );
+    }
+}


### PR DESCRIPTION
- Introduced `TagHoursTotal` metric class in `Nova\Metrics` for calculating tag hours.
- Implemented constructor to select between 'estimated' and 'effective' modes.
- Added `calculate` method to compute total hours based on selected mode.
- Updated `Tag` resource to include `TagHoursTotal` metrics.
- Enhanced localization files to support new metric labels in English and Italian.
- Created comprehensive feature tests in `TagHoursMetricsTest` to ensure correct functionality of the new metrics.
- Ensured tests cover scenarios such as zero hours, sum of story hours, and metric inclusion in Nova Tag resource.
