### PR TITLE
fix(kanban-card): 🐛 ensure thousands separator always used in currenc…

### DIFF
--- a/nova-components/kanban-card/dist/js/card.js
+++ b/nova-components/kanban-card/dist/js/card.js
@@ -710,7 +710,12 @@ Nova.booting((app) => {
              */
             formatCurrency(amount) {
                 try {
-                    return new Intl.NumberFormat('it-IT', { style: 'currency', currency: 'EUR' }).format(Number(amount) || 0);
+                    // it-IT defaults to useGrouping "auto", which omits the thousands separator for values < 10_000.
+                    return new Intl.NumberFormat('it-IT', {
+                        style: 'currency',
+                        currency: 'EUR',
+                        useGrouping: 'always',
+                    }).format(Number(amount) || 0);
                 } catch (e) {
                     return '€ ' + String(amount);
                 }


### PR DESCRIPTION
…y format OC:7795 (#220)

- Updated currency formatting to always use grouping separators for values in the 'it-IT' locale
- This change ensures consistent display of currency values with thousands separator, even for amounts below 10,000
- Utilized `useGrouping: 'always'` option in Intl.NumberFormat configuration