### PR TITLE
feat(models): ✨ add SAL ticket count functionality to Tag model OC:7814

### DIFF
--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\StoryStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -75,8 +76,30 @@ class Tag extends Model
         return url("resources/{$resourcePath}/{$this->taggable_id}");
     }
 
+    /**
+     * Story statuses treated as "closed" for SAL # and Sal t.
+     */
+    public static function salClosedStoryStatusValues(): array
+    {
+        return [
+            StoryStatus::Released->value,
+            StoryStatus::Done->value,
+            StoryStatus::Rejected->value,
+        ];
+    }
+
+    public function salTicketCounts(): array
+    {
+        $statuses = self::salClosedStoryStatusValues();
+
+        return [
+            (int) $this->tagged()->whereIn('status', $statuses)->count(),
+            (int) $this->tagged()->count(),
+        ];
+    }
+
     public function isClosed()
     {
-        return ! $this->tagged()->whereNotIn('status', ['released', 'done'])->exists();
+        return ! $this->tagged()->whereNotIn('status', self::salClosedStoryStatusValues())->exists();
     }
 }

--- a/app/Nova/Tag.php
+++ b/app/Nova/Tag.php
@@ -58,7 +58,12 @@ class Tag extends Resource
                 ->step(
                     1,  // Permette incrementi di 0.5 ore
                 )->onlyOnForms(),
-            Text::make('Sal')->resolveUsing(function () {
+            Text::make('SAL #')->resolveUsing(function () {
+                [$closed, $total] = $this->salTicketCounts();
+
+                return '<span style="font-weight:bold;">['.$closed.']/['.$total.']</span>';
+            })->asHtml()->onlyOnIndex(),
+            Text::make('SAL t')->resolveUsing(function () {
                 $empty = __('Empty');
                 $totalHours = $this->getTotalHoursAttribute() ?? $empty; // Calcola la somma delle ore
                 $estimate = $this->estimate ?? $empty; // Ottieni il valore stimato

--- a/tests/Feature/TagSalTest.php
+++ b/tests/Feature/TagSalTest.php
@@ -18,18 +18,38 @@ class TagSalTest extends TestCase
         return __('Empty');
     }
 
-    // Helper: create a Nova Tag resource and get the 'Sal' field for a tag
+    // Helper: create a Nova Tag resource and get the 'SAL t' field for a tag
     private function getSalField(Tag $tag)
     {
         $request = NovaRequest::create('/nova-api/tags', 'GET');
         $resource = new \App\Nova\Tag($tag);
         $fields = collect($resource->fields($request));
-        $salField = $fields->firstWhere('name', 'Sal');
-        $this->assertNotNull($salField, 'Sal field not found');
+        $salField = $fields->firstWhere('name', 'SAL t');
+        $this->assertNotNull($salField, 'SAL t field not found');
         return $salField;
     }
+    
+    // Helper: create a Nova Tag resource and get the 'SAL #' field for a tag
+    private function getSalHashField(Tag $tag)
+    {
+        $request = NovaRequest::create('/nova-api/tags', 'GET');
+        $resource = new \App\Nova\Tag($tag);
+        $fields = collect($resource->fields($request));
+        $salHashField = $fields->firstWhere('name', 'SAL #');
+        $this->assertNotNull($salHashField, 'SAL # field not found');
+        return $salHashField;
+    }
 
-    // Helper: resolve the Sal field and return the HTML string
+    // Helper: resolve the Sal # field and return the HTML string
+    private function resolveSalHashField(Tag $tag): string
+    {
+        $field = $this->getSalHashField($tag);
+        $field->resolve($tag);
+        $this->assertIsString($field->value, 'SAL # field does not return a string');
+        return $field->value;
+    }
+
+    // Helper: resolve the Sal t field and return the HTML string
     private function resolveSalField(Tag $tag): string
     {
         $salField = $this->getSalField($tag);
@@ -124,5 +144,45 @@ class TagSalTest extends TestCase
 
         $salHtml = $this->resolveSalField($tag);
         $this->assertStringContainsString('color:orange', $salHtml);
+    }
+
+    public function test_sal_hash_shows_zero_when_no_tagged_stories()
+    {
+        $tag = Tag::factory()->create();
+
+        $this->assertSame([0, 0], $tag->salTicketCounts());
+
+        $html = $this->resolveSalHashField($tag);
+        $this->assertStringContainsString('[0]/[0]', $html);
+    }
+
+    public function test_sal_hash_counts_closed_versus_total_stories()
+    {
+        $tag = Tag::factory()->create();
+
+        $released = Story::factory()->create(['status' => StoryStatus::Released]);
+        $inProgress = Story::factory()->create(['status' => StoryStatus::Progress]);
+        $done = Story::factory()->create(['status' => StoryStatus::Done]);
+
+        foreach ([$released, $inProgress, $done] as $story) {
+            $story->tags()->attach($tag->id);
+        }
+
+        $this->assertSame([2, 3], $tag->salTicketCounts());
+
+        $html = $this->resolveSalHashField($tag);
+        $this->assertStringContainsString('[2]/[3]', $html);
+    }
+
+    public function test_tag_is_closed_when_only_rejected_stories_and_sal_t_is_green()
+    {
+        $tag = Tag::factory()->create(['estimate' => 10]);
+        $story = Story::factory()->create(['hours' => 5, 'status' => StoryStatus::Rejected]);
+        $story->tags()->attach($tag->id);
+
+        $this->assertTrue($tag->isClosed());
+
+        $salHtml = $this->resolveSalField($tag);
+        $this->assertStringContainsString('color:green', $salHtml);
     }
 }


### PR DESCRIPTION
- Introduced `salClosedStoryStatusValues` method to define story statuses treated as "closed".
- Added `salTicketCounts` method for calculating closed and total ticket counts based on story statuses.
- Refactored `isClosed` method to utilize the new `salClosedStoryStatusValues` for determining closed status.

feat(nova): ✨ enhance Tag display with SAL ticket counts

- Updated Nova Tag fields to include a new `SAL #` field displaying closed and total ticket counts in bold, using the `salTicketCounts` method.
- Adjusted `SAL #` field to render as HTML for better display on the index view.
- Modified field naming and display logic for improved clarity and functionality.
