### PR TITLE
feat(kanban): unify column collapsing behavior OC:7898

### DIFF
--- a/nova-components/kanban-card/dist/css/card.css
+++ b/nova-components/kanban-card/dist/css/card.css
@@ -301,14 +301,14 @@
     transition: box-shadow 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
 }
 
-/* Compact layout for empty columns only */
-.kanban-column.kanban-column-compact-empty {
+/* Collapsed column: only status title + count badge (all boards) */
+.kanban-column.kanban-column-collapsed {
     flex: 0 0 60px;
     min-width: 60px;
     max-width: 60px;
 }
 
-.kanban-column.kanban-column-compact-empty .kanban-column-header {
+.kanban-column.kanban-column-collapsed .kanban-column-header {
     flex-direction: column;
     justify-content: flex-start;
     gap: 0.5rem;
@@ -316,7 +316,7 @@
     min-height: 160px;
 }
 
-.kanban-column.kanban-column-compact-empty .kanban-column-title {
+.kanban-column.kanban-column-collapsed .kanban-column-title {
     order: 2;
     writing-mode: vertical-rl;
     transform: rotate(180deg);
@@ -325,16 +325,21 @@
     letter-spacing: 0.04em;
 }
 
-.kanban-column.kanban-column-compact-empty .kanban-column-count {
+.kanban-column.kanban-column-collapsed .kanban-column-count {
     order: 1;
 }
 
-.kanban-column.kanban-column-compact-empty .kanban-column-body {
+/* Optional header extras (sums, etc.) never shown when collapsed */
+.kanban-column.kanban-column-collapsed .kanban-column-header-meta {
+    display: none;
+}
+
+.kanban-column.kanban-column-collapsed .kanban-column-body {
     padding: 0.25rem;
     min-height: 24px;
 }
 
-.kanban-column.kanban-column-compact-empty .kanban-column-empty {
+.kanban-column.kanban-column-collapsed .kanban-column-empty {
     display: none;
 }
 
@@ -381,7 +386,15 @@
     color: #d1d5db;
 }
 
-.kanban-column-title-wrap {
+.kanban-column-header-leading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.kanban-column-header-meta {
     display: flex;
     flex-direction: column;
     gap: 0.125rem;

--- a/nova-components/kanban-card/dist/js/card.js
+++ b/nova-components/kanban-card/dist/js/card.js
@@ -74,7 +74,7 @@ Nova.booting((app) => {
                         :key="column.value"
                         class="kanban-column"
                         :class="{
-                            'kanban-column-compact-empty': isColumnCollapsed(column.value),
+                            'kanban-column-collapsed': isColumnCollapsed(column.value),
                             'kanban-column-drop-target': dragOverColumn === column.value && !!draggedItem
                         }"
                         :style="{ borderColor: column.color }"
@@ -82,13 +82,15 @@ Nova.booting((app) => {
                         @dragleave="onDragLeave($event)"
                         @drop="canUpdate && onDrop($event, column.value)"
                     >
-                        <!-- Column Header -->
+                        <!-- Column Header: collapsed = status title + count only; optional meta when expanded -->
                         <div class="kanban-column-header kanban-column-header-clickable" @click.stop="toggleColumnCollapsed(column.value)">
-                            <div class="kanban-column-title-wrap">
+                            <div class="kanban-column-header-leading">
                                 <span class="kanban-column-title">{{ column.label }}</span>
-                                <span v-if="getHeaderSum(column.value) !== null" class="kanban-column-sum">
-                                    {{ formatCurrency(getHeaderSum(column.value)) }}
-                                </span>
+                                <div v-if="!isColumnCollapsed(column.value)" class="kanban-column-header-meta">
+                                    <span v-if="getHeaderSum(column.value) !== null" class="kanban-column-sum">
+                                        {{ formatCurrency(getHeaderSum(column.value)) }}
+                                    </span>
+                                </div>
                             </div>
                             <span class="kanban-column-count" :style="{ backgroundColor: column.color }">
                                 {{ getHeaderCount(column.value) }}
@@ -418,7 +420,10 @@ Nova.booting((app) => {
                 return this.dropIndicator.status === status && this.dropIndicator.targetId === null;
             },
 
-            /** Resolved collapsed state: explicit column flag (toggle) or automatic for empty columns. */
+            /**
+             * Collapsed columns show only status label + count (see .kanban-column-collapsed).
+             * Optional header meta (e.g. column sum) and card list render only when expanded.
+             */
             isColumnCollapsed(status) {
                 if (Object.prototype.hasOwnProperty.call(this.columnCollapsedState, status)) {
                     return this.columnCollapsedState[status] === true;

--- a/nova-components/kanban-card/src/Contracts/AggregatesKanbanColumn.php
+++ b/nova-components/kanban-card/src/Contracts/AggregatesKanbanColumn.php
@@ -14,7 +14,7 @@ interface AggregatesKanbanColumn
      * @param  Request  $request
      * @param  string  $statusValue  The requested column status (virtual statuses included).
      * @param  array  $config  Full card config sent by the frontend.
-     * @return mixed
+     * @return array{count: int, sum?: float|null} count is required; sum is optional and shown in the expanded header only
      */
     public function aggregate(Collection $items, Request $request, string $statusValue, array $config);
 }

--- a/nova-components/kanban-card/src/KanbanCard.php
+++ b/nova-components/kanban-card/src/KanbanCard.php
@@ -359,6 +359,8 @@ class KanbanCard extends Card
      * Aggregate each column using a dedicated class (instead of a non-serializable closure).
      *
      * The controller will load all items for each column (unpaginated) and pass them to the aggregator.
+     * Return shape: ['count' => int, 'sum' => float|null]. The sum is shown in the column header
+     * only while the column is expanded; collapsed columns always show status label + count only.
      *
      * @param  class-string<AggregatesKanbanColumn>  $class
      */


### PR DESCRIPTION
Update CSS and JS to standardize the collation of kanban columns across all boards, showing only status title and count badge when collapsed. Enhance responsiveness by hiding optional meta details in collapsed state. Adjust return type for better data handling.