### PR TITLE
fix(oc:7977): send released email to story creator regardless of role OC:7977

### DIFF
--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -63,9 +63,11 @@ class Story extends Model implements HasMedia
 
             if (
                 isset($story->creator_id)
-                && $story->creator->hasRole($customerRole)
-                && $story->status === $releasedStatus
+                && $currentStatus === $releasedStatus
                 && $story->wasChanged('status')
+                && $story->creator_id !== $story->user_id
+                && $story->creator_id !== $story->tester_id
+                && (!$sender || $sender->id !== $story->creator_id)
             ) {
                 $story->sendStatusUpdatedEmail($story, $story->creator_id, [
                     'highlight_latest_response' => $story->wasChanged('customer_request'),

--- a/docs/features/7977-invio-email-ticket/notes.md
+++ b/docs/features/7977-invio-email-ticket/notes.md
@@ -1,0 +1,19 @@
+> Ticket: oc:7977
+
+# Notes — Invio email ticket al creator indipendentemente dal ruolo
+
+## Deviazioni dal piano
+
+Nessuna.
+
+## Bug trovati
+
+- **Bug latente preesistente:** il blocco creator confrontava `$story->status === $releasedStatus` usando `===` tra un possibile enum object e una stringa — confronto sempre `false`. Corretto nel fix usando `$currentStatus` (variabile già normalizzata a stringa alla riga 62). Nessuna modifica di scope richiesta, era già nel piano.
+
+## Decisioni
+
+- La variabile `$customerRole` definita in `booted()` è rimasta nel closure anche dopo la rimozione del suo utilizzo nel blocco creator — lasciata perché potrebbe essere usata altrove nel metodo in futuro o in altri blocchi non toccati.
+
+## Follow-up
+
+- **Audit log email:** nessun log delle email inviate esiste nel sistema. Se in futuro emergono segnalazioni di email duplicate o mancanti, non è possibile investigare ex-post senza accedere ai log del mail server esterno. Valutare l'aggiunta di un log tabellare come tech debt separato.

--- a/docs/features/7977-invio-email-ticket/overview.md
+++ b/docs/features/7977-invio-email-ticket/overview.md
@@ -1,0 +1,34 @@
+> Ticket: oc:7977
+
+# Invio email ticket al creator indipendentemente dal ruolo
+
+## Cosa cambia
+
+Quando lo status di una Story cambia a `released`, l'email di notifica viene inviata al `creator_id` **qualunque sia il suo ruolo** (customer, developer, admin, manager, editor). In precedenza l'email partiva solo se il creator aveva il ruolo `Customer`.
+
+## Perché
+
+Un developer che apre un ticket per conto proprio non riceveva alcuna notifica quando il ticket veniva rilasciato. Il creatore del ticket deve sempre essere informato dell'aggiornamento, indipendentemente dal suo ruolo nel sistema.
+
+## Requisiti
+
+- [ ] L'email al creator viene inviata su status → `released` per qualsiasi ruolo (rimozione del check `hasRole(Customer)`)
+- [ ] Se `creator_id == user_id` (creator è anche l'assignee), viene inviata una sola email — non due
+- [ ] Se `creator_id == tester_id` (creator è anche il tester), viene inviata una sola email — non due
+- [ ] Test aggiuntivi in `StoryEmailTriggersTest`: creator developer riceve email su Released, deduplicazione creator=assignee, deduplicazione creator=tester
+
+## Rischi
+
+- **Aumento volume email**: rimuovendo il filtro sul ruolo, nuovi utenti (developer, admin, manager) riceveranno email che prima non arrivavano. Mitigato dalla deduplicazione e dal fatto che il trigger rimane limitato al solo status `released`.
+- **Regressione sul caso customer-creator esistente**: la modifica tocca la stessa condizione usata per i customer. Mitigato mantenendo i test esistenti verdi.
+
+## Out of scope
+
+- Notifiche push o in-app al creator (solo email)
+- Cambio del comportamento su status diversi da `released`
+- Modifica al template email `StoryStatusUpdate`
+
+## Moduli toccati
+
+- `app/Models/Story.php` — condizione nel hook `saved()`, righe 64-73
+- `tests/Feature/StoryEmailTriggersTest.php` — nuovi test cases

--- a/docs/features/7977-invio-email-ticket/plan.md
+++ b/docs/features/7977-invio-email-ticket/plan.md
@@ -1,0 +1,187 @@
+> Ticket: oc:7977
+
+# Plan — Invio email ticket al creator indipendentemente dal ruolo
+
+## Step 1 — Fix `app/Models/Story.php`
+
+**File:** `app/Models/Story.php`
+**Blocco da modificare:** hook `saved()`, righe 64-73
+
+### Condizione attuale
+
+```php
+if (
+    isset($story->creator_id)
+    && $story->creator->hasRole($customerRole)
+    && $story->status === $releasedStatus
+    && $story->wasChanged('status')
+) {
+    $story->sendStatusUpdatedEmail($story, $story->creator_id, [
+        'highlight_latest_response' => $story->wasChanged('customer_request'),
+    ]);
+}
+```
+
+### Condizione dopo il fix
+
+```php
+if (
+    isset($story->creator_id)
+    && $currentStatus === $releasedStatus
+    && $story->wasChanged('status')
+    && $story->creator_id !== $story->user_id
+    && $story->creator_id !== $story->tester_id
+    && (!$sender || $sender->id !== $story->creator_id)
+) {
+    $story->sendStatusUpdatedEmail($story, $story->creator_id, [
+        'highlight_latest_response' => $story->wasChanged('customer_request'),
+    ]);
+}
+```
+
+**Modifiche:**
+1. `$story->creator->hasRole($customerRole)` → rimosso (email a qualsiasi ruolo)
+2. `$story->status === $releasedStatus` → `$currentStatus === $releasedStatus` (usa la variabile normalizzata, corregge bug latente enum-vs-string)
+3. `$story->creator_id !== $story->user_id` → deduplicazione con assignee
+4. `$story->creator_id !== $story->tester_id` → deduplicazione con tester
+5. `(!$sender || $sender->id !== $story->creator_id)` → non notificare chi ha fatto l'azione (pattern identico agli altri blocchi)
+
+---
+
+## Step 2 — Test `tests/Feature/StoryEmailTriggersTest.php`
+
+Aggiungere una nuova sezione di test in coda al file, seguendo le convenzioni esistenti (`Bus::fake()`, `DatabaseTransactions`, metodi helper `makeCustomer()`, `makeDeveloper()`).
+
+### Test da aggiungere
+
+#### 2a — Developer-creator riceve email su Released
+
+```php
+/** @test */
+public function creator_developer_receives_email_when_status_set_to_released(): void
+{
+    Bus::fake();
+    $actor = $this->makeDeveloper();
+    $creator = $this->makeDeveloper();
+    $story = $this->makeStory([
+        'creator_id' => $creator->id,
+        'status' => StoryStatus::Progress->value,
+    ]);
+
+    Auth::login($actor);
+    $story->status = StoryStatus::Released->value;
+    $story->save();
+
+    $this->assertCount(1, $this->jobsDispatchedTo($creator->id));
+}
+```
+
+#### 2b — Nessuna email duplicata se creator == assignee
+
+```php
+/** @test */
+public function creator_receives_no_duplicate_email_when_also_assignee(): void
+{
+    Bus::fake();
+    $actor = $this->makeDeveloper();
+    $creator = $this->makeDeveloper();
+    $story = $this->makeStory([
+        'creator_id' => $creator->id,
+        'user_id'    => $creator->id,
+        'status'     => StoryStatus::Progress->value,
+    ]);
+
+    Auth::login($actor);
+    $story->status = StoryStatus::Released->value;
+    $story->save();
+
+    // Al massimo 1 email totale al creator (non 2)
+    $this->assertLessThanOrEqual(1, $this->jobsDispatchedTo($creator->id)->count());
+}
+```
+
+#### 2c — Nessuna email duplicata se creator == tester
+
+```php
+/** @test */
+public function creator_receives_no_duplicate_email_when_also_tester(): void
+{
+    Bus::fake();
+    $actor = $this->makeDeveloper();
+    $creator = $this->makeDeveloper();
+    $story = $this->makeStory([
+        'creator_id' => $creator->id,
+        'tester_id'  => $creator->id,
+        'status'     => StoryStatus::Progress->value,
+    ]);
+
+    Auth::login($actor);
+    $story->status = StoryStatus::Released->value;
+    $story->save();
+
+    $this->assertLessThanOrEqual(1, $this->jobsDispatchedTo($creator->id)->count());
+}
+```
+
+#### 2d — Nessuna email al creator se è lui stesso a fare l'azione (self-release)
+
+```php
+/** @test */
+public function creator_receives_no_email_when_they_set_released_themselves(): void
+{
+    Bus::fake();
+    $creator = $this->makeDeveloper();
+    $story = $this->makeStory([
+        'creator_id' => $creator->id,
+        'status'     => StoryStatus::Progress->value,
+    ]);
+
+    Auth::login($creator);
+    $story->status = StoryStatus::Released->value;
+    $story->save();
+
+    $this->assertCount(0, $this->jobsDispatchedTo($creator->id));
+}
+```
+
+#### 2e — Customer-creator continua a ricevere email (regressione)
+
+```php
+/** @test */
+public function customer_creator_still_receives_email_when_status_set_to_released(): void
+{
+    Bus::fake();
+    $actor = $this->makeDeveloper();
+    $customer = $this->makeCustomer();
+    $story = $this->makeStory([
+        'creator_id' => $customer->id,
+        'status'     => StoryStatus::Progress->value,
+    ]);
+
+    Auth::login($actor);
+    $story->status = StoryStatus::Released->value;
+    $story->save();
+
+    $this->assertCount(1, $this->jobsDispatchedTo($customer->id));
+}
+```
+
+---
+
+## Step 3 — Verifica test esistenti
+
+Dopo le modifiche, eseguire dentro il container:
+
+```bash
+php artisan test --filter=StoryEmailTriggersTest
+```
+
+Tutti i test esistenti devono restare verdi. I nuovi test devono passare.
+
+---
+
+## Commit convention
+
+```
+fix(oc:7977): send released email to story creator regardless of role
+```

--- a/tests/Feature/StoryEmailTriggersTest.php
+++ b/tests/Feature/StoryEmailTriggersTest.php
@@ -387,4 +387,99 @@ class StoryEmailTriggersTest extends TestCase
         });
     }
 
+    // =========================================================================
+    // OC:7977 — Creator riceve email su Released indipendentemente dal ruolo
+    // =========================================================================
+
+    /** @test */
+    public function creator_developer_receives_email_when_status_set_to_released(): void
+    {
+        Bus::fake();
+        $actor = $this->makeDeveloper();
+        $creator = $this->makeDeveloper();
+        $story = $this->makeStory([
+            'creator_id' => $creator->id,
+            'status' => StoryStatus::Progress->value,
+        ]);
+
+        Auth::login($actor);
+        $story->status = StoryStatus::Released->value;
+        $story->save();
+
+        $this->assertCount(1, $this->jobsDispatchedTo($creator->id));
+    }
+
+    /** @test */
+    public function creator_receives_no_duplicate_email_when_also_assignee(): void
+    {
+        Bus::fake();
+        $actor = $this->makeDeveloper();
+        $creator = $this->makeDeveloper();
+        $story = $this->makeStory([
+            'creator_id' => $creator->id,
+            'user_id' => $creator->id,
+            'status' => StoryStatus::Progress->value,
+        ]);
+
+        Auth::login($actor);
+        $story->status = StoryStatus::Released->value;
+        $story->save();
+
+        $this->assertLessThanOrEqual(1, $this->jobsDispatchedTo($creator->id)->count());
+    }
+
+    /** @test */
+    public function creator_receives_no_duplicate_email_when_also_tester(): void
+    {
+        Bus::fake();
+        $actor = $this->makeDeveloper();
+        $creator = $this->makeDeveloper();
+        $story = $this->makeStory([
+            'creator_id' => $creator->id,
+            'tester_id' => $creator->id,
+            'status' => StoryStatus::Progress->value,
+        ]);
+
+        Auth::login($actor);
+        $story->status = StoryStatus::Released->value;
+        $story->save();
+
+        $this->assertLessThanOrEqual(1, $this->jobsDispatchedTo($creator->id)->count());
+    }
+
+    /** @test */
+    public function creator_receives_no_email_when_they_set_released_themselves(): void
+    {
+        Bus::fake();
+        $creator = $this->makeDeveloper();
+        $story = $this->makeStory([
+            'creator_id' => $creator->id,
+            'status' => StoryStatus::Progress->value,
+        ]);
+
+        Auth::login($creator);
+        $story->status = StoryStatus::Released->value;
+        $story->save();
+
+        $this->assertCount(0, $this->jobsDispatchedTo($creator->id));
+    }
+
+    /** @test */
+    public function customer_creator_still_receives_email_when_status_set_to_released(): void
+    {
+        Bus::fake();
+        $actor = $this->makeDeveloper();
+        $customer = $this->makeCustomer();
+        $story = $this->makeStory([
+            'creator_id' => $customer->id,
+            'status' => StoryStatus::Progress->value,
+        ]);
+
+        Auth::login($actor);
+        $story->status = StoryStatus::Released->value;
+        $story->save();
+
+        $this->assertCount(1, $this->jobsDispatchedTo($customer->id));
+    }
+
 }


### PR DESCRIPTION
- Remove hasRole(Customer) guard: any creator now receives the email on Released
- Fix latent bug: use $currentStatus (normalized string) instead of $story->status (may be enum object) in the released comparison
- Add deduplication guards: skip creator email if creator is also assignee or tester
- Add self-notification guard: creator does not receive email if they set the status themselves
- Add 5 regression tests in StoryEmailTriggersTest covering all new cases