### PR TITLE
fix(email): 🐛 remove unnecessary guards for creator email notifications OC:7977

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,15 +78,28 @@ Each model has a corresponding Nova Resource. Nova is the primary interface. Cus
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Invio email creator su Released | oc:7977 | `app/Models/Story.php`, `tests/Feature/StoryEmailTriggersTest.php` | Il creator riceve sempre l'email su status→released, indipendentemente da ruolo, da chi agisce, e dall'auto-assign tester |
 | API endpoint GET /me | oc:7974 | `routes/api.php`, `tests/Feature/Api/MeEndpointTest.php` | Restituisce id, name, email dell'utente autenticato via Sanctum |
 
 ## Decisioni architetturali
+
+### Invio email creator su Released (oc:7977)
+- **Nessuna guard sul blocco creator-released**: rimosse tutte le guard di deduplicazione (`creator != tester`, `creator != assignee`) e la self-notification. Per `released`, nessun altro path notifica tester o assignee — le guard erano inutili e bloccavano i developer-creator (auto-assign `tester_id = creator_id` nel hook `created`).
+- **Non toccare il hook `created`**: il bug era nella logica email, non nell'auto-assign del tester. Principio: minimo scope.
 
 ### API endpoint GET /me (oc:7974)
 - Closure inline in `routes/api.php` invece di un controller dedicato — accettato consapevolmente per semplicità; il progetto non usa `php artisan route:cache` in produzione
 
 ## Testing
-Tests use the real PostgreSQL database (not SQLite/in-memory). See `phpunit.xml` — `DB_CONNECTION` is not overridden. Run tests inside the container.
+Tests use the real PostgreSQL database (not SQLite/in-memory). Run tests inside the container.
+
+`phpunit.xml` punta a `orchestrator_test` ma il DB potrebbe non esistere (extension `pgvector` non disponibile su PG 14 blocca le migration). Usare il DB principale con:
+
+```bash
+DB_DATABASE=orchestrator php artisan test --filter=TestClassName
+```
+
+Sicuro perché tutti i test Feature usano `DatabaseTransactions` (rollback automatico).
 
 ## Decisioni architetturali
 

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -65,9 +65,6 @@ class Story extends Model implements HasMedia
                 isset($story->creator_id)
                 && $currentStatus === $releasedStatus
                 && $story->wasChanged('status')
-                && $story->creator_id !== $story->user_id
-                && $story->creator_id !== $story->tester_id
-                && (!$sender || $sender->id !== $story->creator_id)
             ) {
                 $story->sendStatusUpdatedEmail($story, $story->creator_id, [
                     'highlight_latest_response' => $story->wasChanged('customer_request'),

--- a/docs/features/7977-invio-email-ticket/notes.md
+++ b/docs/features/7977-invio-email-ticket/notes.md
@@ -4,16 +4,23 @@
 
 ## Deviazioni dal piano
 
-Nessuna.
+### Ciclo 2 (2026-06-10) — secondo fix dopo PR #228
+
+- **Root cause ciclo 2:** PR #228 aveva rimosso `hasRole(Customer)` ma lasciato guard `creator_id !== tester_id` e `creator_id !== user_id`. Per i developer il hook `created` auto-assegna `tester_id = creator_id`, quindi la guard bloccava sempre l'email. I test del ciclo 1 non coprivano questo scenario perché `makeStory()` non autentica l'utente alla creazione, bypassando l'auto-assign del tester.
+- **Approccio scelto:** rimosse tutte le guard dal blocco creator-released, inclusa la self-notification. La logica è ora: "il creator riceve sempre l'email quando il ticket va in released, punto." Semplice e corretto.
+- **Guard self-notification rimossa:** a differenza del piano originale, il creator riceve l'email anche se è lui stesso a mettere in released. Scelta deliberata: il creator vuole sempre sapere dello status change.
 
 ## Bug trovati
 
-- **Bug latente preesistente:** il blocco creator confrontava `$story->status === $releasedStatus` usando `===` tra un possibile enum object e una stringa — confronto sempre `false`. Corretto nel fix usando `$currentStatus` (variabile già normalizzata a stringa alla riga 62). Nessuna modifica di scope richiesta, era già nel piano.
+- **Bug latente preesistente (ciclo 1):** confronto enum/string in `$story->status === $releasedStatus` — sempre `false`. Risolto in PR #228.
+- **Bug residuo (ciclo 2):** guard di deduplicazione `creator_id !== tester_id` bloccava l'email per tutti i developer-creator (tester auto-assegnato = creator in `created` hook). I test passavano perché non replicavano il comportamento reale del `created` hook.
 
 ## Decisioni
 
-- La variabile `$customerRole` definita in `booted()` è rimasta nel closure anche dopo la rimozione del suo utilizzo nel blocco creator — lasciata perché potrebbe essere usata altrove nel metodo in futuro o in altri blocchi non toccati.
+- La variabile `$customerRole` definita in `booted()` è rimasta nel closure anche dopo la rimozione del suo utilizzo — lasciata perché usata in altri blocchi del closure.
+- Non modificato il hook `created` (auto-assign `tester_id = creator_id`): il bug era nella logica email, non nell'auto-assign.
 
 ## Follow-up
 
-- **Audit log email:** nessun log delle email inviate esiste nel sistema. Se in futuro emergono segnalazioni di email duplicate o mancanti, non è possibile investigare ex-post senza accedere ai log del mail server esterno. Valutare l'aggiunta di un log tabellare come tech debt separato.
+- **Audit log email:** nessun log delle email inviate esiste nel sistema. Valutare aggiunta log tabellare come tech debt separato.
+- **DB test:** il database `orchestrator_test` richiedeva la creazione manuale + extension `pgvector` non disponibile su PostgreSQL 14. I test vanno runnati con `DB_DATABASE=orchestrator` (main DB, sicuro grazie a `DatabaseTransactions`). Documentare in CLAUDE.md.

--- a/docs/features/7977-invio-email-ticket/overview.md
+++ b/docs/features/7977-invio-email-ticket/overview.md
@@ -4,18 +4,20 @@
 
 ## Cosa cambia
 
-Quando lo status di una Story cambia a `released`, l'email di notifica viene inviata al `creator_id` **qualunque sia il suo ruolo** (customer, developer, admin, manager, editor). In precedenza l'email partiva solo se il creator aveva il ruolo `Customer`.
+Quando lo status di una Story cambia a `released`, l'email di notifica viene inviata al `creator_id` **sempre e incondizionatamente** — qualunque sia il suo ruolo e chiunque abbia eseguito l'azione. In precedenza l'email partiva solo se il creator aveva il ruolo `Customer`, e guard di deduplicazione (creator=tester, creator=assignee) bloccavano erroneamente l'email in molti casi reali.
 
 ## Perché
 
-Un developer che apre un ticket per conto proprio non riceveva alcuna notifica quando il ticket veniva rilasciato. Il creatore del ticket deve sempre essere informato dell'aggiornamento, indipendentemente dal suo ruolo nel sistema.
+Un developer che apre un ticket per conto proprio non riceveva alcuna notifica quando il ticket veniva rilasciato. La causa radice era duplice: (1) guard `hasRole(Customer)` rimosso nel ciclo precedente (PR #228), ma (2) le guard di deduplicazione `creator_id !== tester_id` e `creator_id !== user_id` bloccavano comunque l'email perché per i developer il hook `created` auto-assegna `tester_id = creator_id`. Il creatore del ticket deve sempre essere informato del rilascio.
 
 ## Requisiti
 
-- [ ] L'email al creator viene inviata su status → `released` per qualsiasi ruolo (rimozione del check `hasRole(Customer)`)
-- [ ] Se `creator_id == user_id` (creator è anche l'assignee), viene inviata una sola email — non due
-- [ ] Se `creator_id == tester_id` (creator è anche il tester), viene inviata una sola email — non due
-- [ ] Test aggiuntivi in `StoryEmailTriggersTest`: creator developer riceve email su Released, deduplicazione creator=assignee, deduplicazione creator=tester
+- [x] L'email al creator viene inviata su status → `released` per qualsiasi ruolo
+- [x] L'email al creator viene inviata anche se creator == tester (caso reale: developer crea ticket)
+- [x] L'email al creator viene inviata anche se creator == assignee
+- [x] L'email al creator viene inviata anche se è il creator stesso a mettere in released
+- [x] Test di regressione: `creator_receives_no_duplicate_email_when_also_tester` → `assertCount(1)` (non più `assertLessThanOrEqual`)
+- [x] Nuovo test canary: `creator_receives_email_when_tester_sets_released`
 
 ## Rischi
 

--- a/tests/Feature/StoryEmailTriggersTest.php
+++ b/tests/Feature/StoryEmailTriggersTest.php
@@ -425,7 +425,7 @@ class StoryEmailTriggersTest extends TestCase
         $story->status = StoryStatus::Released->value;
         $story->save();
 
-        $this->assertLessThanOrEqual(1, $this->jobsDispatchedTo($creator->id)->count());
+        $this->assertCount(1, $this->jobsDispatchedTo($creator->id));
     }
 
     /** @test */
@@ -444,11 +444,11 @@ class StoryEmailTriggersTest extends TestCase
         $story->status = StoryStatus::Released->value;
         $story->save();
 
-        $this->assertLessThanOrEqual(1, $this->jobsDispatchedTo($creator->id)->count());
+        $this->assertCount(1, $this->jobsDispatchedTo($creator->id));
     }
 
     /** @test */
-    public function creator_receives_no_email_when_they_set_released_themselves(): void
+    public function creator_receives_email_even_when_they_set_released_themselves(): void
     {
         Bus::fake();
         $creator = $this->makeDeveloper();
@@ -461,7 +461,26 @@ class StoryEmailTriggersTest extends TestCase
         $story->status = StoryStatus::Released->value;
         $story->save();
 
-        $this->assertCount(0, $this->jobsDispatchedTo($creator->id));
+        $this->assertCount(1, $this->jobsDispatchedTo($creator->id));
+    }
+
+    /** @test */
+    public function creator_receives_email_when_tester_sets_released(): void
+    {
+        Bus::fake();
+        $creator = $this->makeCustomer();
+        $tester = $this->makeDeveloper();
+        $story = $this->makeStory([
+            'creator_id' => $creator->id,
+            'tester_id' => $tester->id,
+            'status' => StoryStatus::Tested->value,
+        ]);
+
+        Auth::login($tester);
+        $story->status = StoryStatus::Released->value;
+        $story->save();
+
+        $this->assertCount(1, $this->jobsDispatchedTo($creator->id));
     }
 
     /** @test */


### PR DESCRIPTION
- Removed redundant deduplication guards (`creator_id !== tester_id` and `creator_id !== user_id`) in `Story.php` that prevented email notifications to the creator when status changed to `released`.
- Updated the documentation in `CLAUDE.md` to reflect changes in the email notification logic.
- Enhanced test coverage in `StoryEmailTriggersTest.php` to ensure the creator always receives an email when their story is released, including scenarios where the creator is also the tester or assignee.
- Added a new test case `creator_receives_email_when_tester_sets_released` to validate the email notification workflow.
- Updated existing test case assertions from `assertLessThanOrEqual(1)` to `assertCount(1)` for clarity and precision.
