### PR TITLE
fix(oc:8091): skip creation email for Scrum-type stories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,11 +81,16 @@ Each model has a corresponding Nova Resource. Nova is the primary interface. Cus
 | PDF preventivo — logo visibile | oc:8047 | `resources/views/quote-pdf.blade.php`, `public/images/logo.png` | Usa `file://` path invece di data URI base64; DomPDF non renderizza data URI in questo setup |
 | Sync calendario asincrona con debounce | oc:8044 | `app/Jobs/SyncDeveloperCalendarJob.php`, `app/Observers/StoryObserver.php`, `app/Console/Commands/SyncStoriesWithGoogleCalendar.php`, `tests/Feature/SyncDeveloperCalendarJobTest.php` | La sync Google Calendar al save di una Story è un job in coda (debounce 60s, unique per email); save Nova < 2s, bulk edit senza timeout |
 | Hetzner Monitoring | oc:7944 | `config/hetzner.php`, `app/Services/HetznerApiService.php`, `app/Http/Controllers/HetznerMonitoringController.php`, `app/Exports/HetznerExport.php`, `nova-components/hetzner-monitoring/`, `app/Nova/Dashboards/HetznerMonitoring.php` | Dashboard Nova con tabella per progetto Hetzner: server, floating IP, volumes, LB, snapshot. Cache Redis 15 min. Export CSV. |
+| Fix email creazione ticket Scrum | oc:8091 | `app/Models/Story.php`, `tests/Feature/StoryEmailTriggersTest.php` | Alla creazione di un ticket di tipo Scrum nessuna mail viene inviata ai developer; tutti gli altri tipi inviano normalmente |
 | Invio email alla creazione ticket | oc:8040 | `app/Mail/DevNewStoryCreated.php`, `resources/views/mails/dev-new-story-created.blade.php`, `app/Models/Story.php`, `tests/Feature/StoryEmailTriggersTest.php` | Alla creazione di qualsiasi ticket tutti i dev ricevono email: `CustomerNewStoryCreated` se creator è customer, `DevNewStoryCreated` altrimenti |
 | Invio email creator su Released | oc:7977 | `app/Models/Story.php`, `tests/Feature/StoryEmailTriggersTest.php` | Il creator riceve sempre l'email su status→released, indipendentemente da ruolo, da chi agisce, e dall'auto-assign tester |
 | API endpoint GET /me | oc:7974 | `routes/api.php`, `tests/Feature/Api/MeEndpointTest.php` | Restituisce id, name, email dell'utente autenticato via Sanctum |
 
 ## Decisioni architetturali
+
+### Fix email creazione ticket Scrum (oc:8091)
+- **Guardia solo sull'invio email, non sull'assegnazione**: il `return` nell'hook `created` è posizionato dopo `$story->save()` (che assegna `creator_id`, `tester_id`) e prima del loop developer. I metadati del ticket Scrum vengono sempre popolati correttamente.
+- **`$story->type` è stringa, non enum castata**: il modello `Story` non ha `$casts` per il campo `type`. Il confronto `=== StoryType::Scrum->value` è safe. Se in futuro si aggiunge il cast Eloquent, aggiornare la guardia.
 
 ### PDF preventivo — logo via file:// (oc:8047)
 - **DomPDF non renderizza data URI PNG/SVG**: in questo setup (`barryvdh/laravel-dompdf ^3.0`), le immagini passate come `data:image/...;base64,...` in tag `<img>` non vengono renderizzate. Usare sempre `file://` + path assoluto per le immagini locali nei template PDF.

--- a/app/Models/Story.php
+++ b/app/Models/Story.php
@@ -165,6 +165,10 @@ class Story extends Model implements HasMedia
                 }
 
                 $story->save();
+                // Scrum tickets are internal planning tasks: no email notification on creation.
+                if ($story->type === StoryType::Scrum->value) {
+                    return;
+                }
                 $developers = User::whereJsonContains('roles', UserRole::Developer)->get();
                 foreach ($developers as $developer) {
                     try {

--- a/docs/features/8091-fix-invio-email-per-ticket-di-tipo-scrum/notes.md
+++ b/docs/features/8091-fix-invio-email-per-ticket-di-tipo-scrum/notes.md
@@ -1,0 +1,17 @@
+> Ticket: oc:8091
+
+# Notes — Fix invio email per ticket di tipo Scrum
+
+## Deviazioni dal piano
+
+Nessuna deviazione strutturale. Il piano è stato seguito linearmente.
+
+## Decisioni
+
+- **`assertNothingSent()` invece di `assertNotSent(CustomerNewStoryCreated::class)`**: dopo la code review, rafforzata l'assertion del test per coprire qualsiasi mail class, non solo `CustomerNewStoryCreated`. Più aderente all'intenzione dichiarata dal nome del test.
+- **Commento inline sulla guardia**: aggiunto `// Scrum tickets are internal planning tasks: no email notification on creation.` per rendere esplicito il perché del `return` anticipato in mezzo alla closure.
+
+## Follow-up
+
+- Il bypass customer via API (creazione ticket Scrum con type esplicito via `POST /api/stories`) è out of scope per questo ticket ma potrebbe essere indirizzato in futuro con una validation nel `StoryApiRequest`.
+- Il campo `type` non ha un Eloquent cast nel modello `Story`. Se in futuro viene aggiunto `$casts = ['type' => StoryType::class]`, aggiornare la guardia per confrontare l'enum direttamente invece del valore stringa.

--- a/docs/features/8091-fix-invio-email-per-ticket-di-tipo-scrum/overview.md
+++ b/docs/features/8091-fix-invio-email-per-ticket-di-tipo-scrum/overview.md
@@ -1,0 +1,34 @@
+> Ticket: oc:8091
+
+# Fix invio email per ticket di tipo Scrum
+
+## Cosa cambia
+
+Alla creazione di un ticket di tipo `Scrum`, il sistema non invia più la mail `CustomerNewStoryCreated` ai developer. Tutti gli altri tipi di ticket (`Bug`, `Feature`, `Help desk`) continuano a generare la notifica email come prima.
+
+## Perché
+
+I ticket Scrum sono ticket interni di gestione/pianificazione del team. Non rappresentano richieste di lavoro esterne né task assegnati a singoli developer, quindi le notifiche email sono rumore inutile che distrae dal lavoro reale.
+
+## Requisiti
+
+- [ ] Alla creazione di un ticket con `type = Scrum`, nessuna mail viene inviata ai developer
+- [ ] La logica di assegnazione (`creator_id`, `tester_id`) rimane invariata anche per i ticket Scrum
+- [ ] Per tutti gli altri tipi (`Bug`, `Feature`, `Help desk`) il comportamento email è identico a prima
+- [ ] Un test di regressione verifica esplicitamente il blocco email per i ticket Scrum
+
+## Rischi
+
+- **Falso negativo sulla guardia**: se `$story->type` è `null` al momento del check (tipo non settato), la guardia non scatta e l'email viene inviata. Mitigazione: la guardia usa `=== StoryType::Scrum->value`, quindi `null` e altri tipi non vengono bloccati — comportamento corretto per design.
+- **Regressione su altri tipi**: una guardia troppo larga potrebbe silenziare email su `Bug`/`Feature`. Mitigazione: check esplicito solo su `Scrum`, test che verifica i tipi non-Scrum continuano a inviare.
+
+## Out of scope
+
+- Email di cambio status (todo, testing, tested, released) — restano invariate anche per ticket Scrum
+- Notifiche in-app Nova — non toccate
+- Creazione ticket Scrum da parte di customer — impossibile per vincolo di ruolo, nessuna logica aggiuntiva necessaria
+
+## Moduli toccati
+
+- `app/Models/Story.php` — hook `created`: aggiunta guardia prima del loop di invio mail
+- `tests/Feature/StoryEmailTriggersTest.php` — aggiunto test di regressione

--- a/docs/features/8091-fix-invio-email-per-ticket-di-tipo-scrum/plan.md
+++ b/docs/features/8091-fix-invio-email-per-ticket-di-tipo-scrum/plan.md
@@ -1,0 +1,52 @@
+> Ticket: oc:8091
+
+# Plan — Fix invio email per ticket di tipo Scrum
+
+## Task 1 — Aggiungere la guardia nell'hook `created` di `Story.php`
+
+**File:** `app/Models/Story.php`
+
+Nel metodo `booted()`, dentro l'hook `static::created(function (Story $story) { ... })`, aggiungere il check subito dopo `$story->save()` (riga ~167) e prima del loop `foreach ($developers as $developer)`:
+
+```php
+if ($story->type === StoryType::Scrum->value) {
+    return;
+}
+```
+
+La guardia deve stare **dopo** `$story->save()` (che assegna `creator_id`, `tester_id`) e **prima** di `$developers = User::whereJsonContains(...)`. In questo modo:
+- L'assegnazione dei metadati avviene sempre
+- La query sui developer non viene nemmeno eseguita per ticket Scrum
+- L'invio mail è bloccato
+
+## Task 2 — Aggiungere il test di regressione in `StoryEmailTriggersTest.php`
+
+**File:** `tests/Feature/StoryEmailTriggersTest.php`
+
+Aggiungere un test nella sezione della creazione ticket (dopo i test esistenti per oc:8040):
+
+```php
+/** @test */
+public function scrum_story_creation_does_not_send_email_to_developers(): void
+{
+    Mail::fake();
+    $developer = $this->makeDeveloper();
+    Auth::login($developer);
+
+    Story::query()->create([
+        'name' => 'Scrum ticket',
+        'type' => StoryType::Scrum->value,
+        'status' => StoryStatus::New->value,
+    ]);
+
+    Mail::assertNotSent(CustomerNewStoryCreated::class);
+}
+```
+
+Il developer viene creato esplicitamente per garantire che il loop `User::whereJsonContains('roles', Developer)` abbia almeno un risultato — l'assertion `assertNotSent` è significativa solo se c'è qualcuno a cui potenzialmente inviare.
+
+## Task 3 — Commit
+
+```
+fix(oc:8091): skip creation email for Scrum-type stories
+```

--- a/tests/Feature/StoryEmailTriggersTest.php
+++ b/tests/Feature/StoryEmailTriggersTest.php
@@ -541,4 +541,24 @@ class StoryEmailTriggersTest extends TestCase
 
         Mail::assertSent(CustomerNewStoryCreated::class);
     }
+
+    // ===================================================================================
+    // OC:8091 — Nessuna mail alla creazione di ticket di tipo Scrum
+    // ===================================================================================
+
+    /** @test */
+    public function scrum_story_creation_does_not_send_email_to_developers(): void
+    {
+        Mail::fake();
+        $developer = $this->makeDeveloper();
+
+        Auth::login($developer);
+        Story::query()->create([
+            'name' => 'Scrum ticket',
+            'type' => StoryType::Scrum->value,
+            'status' => StoryStatus::New->value,
+        ]);
+
+        Mail::assertNothingSent();
+    }
 }


### PR DESCRIPTION
## Summary

- Aggiunta guardia nell'hook `created` di `Story.php`: se il ticket è di tipo `Scrum`, l'invio di `CustomerNewStoryCreated` ai developer viene saltato
- La logica di assegnazione (`creator_id`, `tester_id`) rimane invariata per tutti i tipi
- Aggiunto test di regressione `scrum_story_creation_does_not_send_email_to_developers` con `Mail::assertNothingSent()`

## Test plan

- [ ] Creare un ticket di tipo Scrum e verificare che nessun developer riceva email
- [ ] Creare un ticket di tipo Bug/Feature/Helpdesk e verificare che le email vengano inviate normalmente
- [ ] Eseguire `DB_DATABASE=orchestrator php artisan test --filter=StoryEmailTriggersTest` dentro il container

🤖 Generated with [Claude Code](https://claude.com/claude-code)