### PR TITLE
feat(oc:8192): aggiungi metrica Todo >1g nella card team performance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Each model has a corresponding Nova Resource. Nova is the primary interface. Cus
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Metrica "Todo >1g" nella card team performance | oc:8192 | `app/Services/Metrics/StoryMetricsCalculator.php`, `app/Http/Controllers/Nova/TeamPerformanceController.php`, `nova-components/team-performance/dist/js/card.js` | Nuovo metodo `todoStagnationTotalDays()` (somma tutti gli intervalli todo); esposto come colonna per-ticket e KPI aggregato; etichetta "Todo >1g" perché `workingDaysBetween` conta giorni interi; 0 giorni mostrato come `—` |
 | Fix download allegati (path generator ibrido) | oc:8028 | `app/Services/MediaLibrary/OrchestratorPathGenerator.php`, `app/Providers/AppServiceProvider.php` | Generator C→B→A ripristina accesso ai 605/631 media legacy; wm-package sovrascriveva path_generator con WmfePathGenerator |
 | PDF preventivo — logo visibile | oc:8047 | `resources/views/quote-pdf.blade.php`, `public/images/logo.png` | Usa `file://` path invece di data URI base64; DomPDF non renderizza data URI in questo setup |
 | Sync calendario asincrona con debounce | oc:8044 | `app/Jobs/SyncDeveloperCalendarJob.php`, `app/Observers/StoryObserver.php`, `app/Console/Commands/SyncStoriesWithGoogleCalendar.php`, `tests/Feature/SyncDeveloperCalendarJobTest.php` | La sync Google Calendar al save di una Story è un job in coda (debounce 60s, unique per email); save Nova < 2s, bulk edit senza timeout |
@@ -91,6 +92,12 @@ Each model has a corresponding Nova Resource. Nova is the primary interface. Cus
 | API endpoint GET /me | oc:7974 | `routes/api.php`, `tests/Feature/Api/MeEndpointTest.php` | Restituisce id, name, email dell'utente autenticato via Sanctum |
 
 ## Decisioni architetturali
+
+### Metrica "Todo >1g" nella card team performance (oc:8192)
+- **`workingDaysBetween` conta giorni interi**: un ticket in todo per meno di un giorno lavorativo restituisce 0. L'etichetta "Todo >1g" chiarisce che si tratta di giorni completi, non ore. Valori 0 vengono mostrati come `—`.
+- **Cache Redis `team_perf_avg_{year}_q{quarter}`**: TTL 1h. Dopo un deploy che aggiunge campi all'aggregato, svuotare le chiavi manualmente (`Cache::forget(...)`) altrimenti il frontend riceve il vecchio JSON senza i nuovi campi.
+- **`card.js` modificato direttamente**: nessun sorgente Vue — stesso pattern di `kanban-card`. Validare sempre con `node --check` prima del commit.
+- **Rollback non atomico**: rollback del solo PHP senza rollback di `card.js` causa `undefined` invece di `—` nel frontend. Entrambi i file devono essere rollbackati insieme.
 
 ### Fix download allegati — path generator ibrido (oc:8028)
 - **wm-package sovrascrive `path_generator` e `disk_name`**: il suo ServiceProvider fa `array_merge` sulla config di `media-library`, rimpiazzando `CustomPathGenerator` con `WmfePathGenerator` e `disk_name` con `wmfe`. `AppServiceProvider::register()` deve ripristinare entrambi *dopo* il boot di wm-package.

--- a/app/Http/Controllers/Nova/TeamPerformanceController.php
+++ b/app/Http/Controllers/Nova/TeamPerformanceController.php
@@ -114,6 +114,7 @@ class TeamPerformanceController extends Controller
                 'commit_count'          => $commits ?: null,
                 'pr_count'              => $prs->count() ?: null,
                 'change_requests_count' => $prs->sum('change_requests_count') ?: null,
+                'todo_stagnation_days'  => $this->calc->todoStagnationTotalDays($story->id),
             ];
         })->toArray();
     }
@@ -175,22 +176,24 @@ class TeamPerformanceController extends Controller
     {
         if (empty($tickets)) {
             return [
-                'story_count'          => 0,
-                'avg_cycle_time_hours' => null,
-                'avg_reopen_count'     => null,
-                'on_time_rate'         => null,
-                'avg_commit_count'     => null,
-                'avg_pr_count'         => null,
-                'avg_change_requests'  => null,
+                'story_count'              => 0,
+                'avg_cycle_time_hours'     => null,
+                'avg_reopen_count'         => null,
+                'on_time_rate'             => null,
+                'avg_commit_count'         => null,
+                'avg_pr_count'             => null,
+                'avg_change_requests'      => null,
+                'avg_todo_stagnation_days' => null,
             ];
         }
 
-        $cycleTimes = array_filter(array_column($tickets, 'cycle_time_hours'), fn ($v) => $v !== null);
-        $reopens    = array_column($tickets, 'reopen_count');
-        $onTimes    = array_filter(array_column($tickets, 'on_time'), fn ($v) => $v !== null);
-        $commits    = array_filter(array_column($tickets, 'commit_count'), fn ($v) => $v !== null);
-        $prs        = array_filter(array_column($tickets, 'pr_count'), fn ($v) => $v !== null);
-        $changeReqs = array_filter(array_column($tickets, 'change_requests_count'), fn ($v) => $v !== null);
+        $cycleTimes     = array_filter(array_column($tickets, 'cycle_time_hours'), fn ($v) => $v !== null);
+        $reopens        = array_column($tickets, 'reopen_count');
+        $onTimes        = array_filter(array_column($tickets, 'on_time'), fn ($v) => $v !== null);
+        $commits        = array_filter(array_column($tickets, 'commit_count'), fn ($v) => $v !== null);
+        $prs            = array_filter(array_column($tickets, 'pr_count'), fn ($v) => $v !== null);
+        $changeReqs     = array_filter(array_column($tickets, 'change_requests_count'), fn ($v) => $v !== null);
+        $todoStagnation = array_filter(array_column($tickets, 'todo_stagnation_days'), fn ($v) => $v !== null);
         $capped     = count(array_filter($cycleTimes, fn ($v) => $v >= 80));
 
         return [
@@ -201,7 +204,8 @@ class TeamPerformanceController extends Controller
             'on_time_rate'         => count($onTimes) ? round(count(array_filter($onTimes)) / count($onTimes) * 100, 1) : null,
             'avg_commit_count'     => count($commits) ? round(array_sum($commits) / count($commits), 1) : null,
             'avg_pr_count'         => count($prs) ? round(array_sum($prs) / count($prs), 1) : null,
-            'avg_change_requests'  => count($changeReqs) ? round(array_sum($changeReqs) / count($changeReqs), 1) : null,
+            'avg_change_requests'      => count($changeReqs) ? round(array_sum($changeReqs) / count($changeReqs), 1) : null,
+            'avg_todo_stagnation_days' => count($todoStagnation) ? round(array_sum($todoStagnation) / count($todoStagnation), 1) : null,
         ];
     }
 
@@ -228,7 +232,7 @@ class TeamPerformanceController extends Controller
             ->values();
 
         if ($perDeveloper->isEmpty()) {
-            return ['story_count' => 0, 'avg_cycle_time_hours' => null, 'avg_reopen_count' => null, 'on_time_rate' => null, 'avg_commit_count' => null, 'avg_pr_count' => null, 'avg_change_requests' => null];
+            return ['story_count' => 0, 'avg_cycle_time_hours' => null, 'avg_reopen_count' => null, 'on_time_rate' => null, 'avg_commit_count' => null, 'avg_pr_count' => null, 'avg_change_requests' => null, 'avg_todo_stagnation_days' => null];
         }
 
         $avg = fn (string $key) => $perDeveloper->pluck($key)->filter(fn ($v) => $v !== null)->average();
@@ -241,7 +245,8 @@ class TeamPerformanceController extends Controller
             'on_time_rate'         => $avg('on_time_rate') !== null ? round($avg('on_time_rate'), 1) : null,
             'avg_commit_count'     => $avg('avg_commit_count') !== null ? round($avg('avg_commit_count'), 1) : null,
             'avg_pr_count'         => $avg('avg_pr_count') !== null ? round($avg('avg_pr_count'), 1) : null,
-            'avg_change_requests'  => $avg('avg_change_requests') !== null ? round($avg('avg_change_requests'), 1) : null,
+            'avg_change_requests'      => $avg('avg_change_requests') !== null ? round($avg('avg_change_requests'), 1) : null,
+            'avg_todo_stagnation_days' => $avg('avg_todo_stagnation_days') !== null ? round($avg('avg_todo_stagnation_days'), 1) : null,
         ];
     }
 }

--- a/app/Services/Metrics/StoryMetricsCalculator.php
+++ b/app/Services/Metrics/StoryMetricsCalculator.php
@@ -128,6 +128,30 @@ class StoryMetricsCalculator
     }
 
     /**
+     * Giorni lavorativi totali in cui la story è rimasta in `todo`, sommando tutti gli intervalli.
+     * Restituisce null se non esistono log con status `todo`.
+     */
+    public function todoStagnationTotalDays(int $storyId): ?int
+    {
+        $logs = $this->getStatusLogs($storyId);
+        $totalDays = 0;
+        $hasTodo = false;
+
+        for ($i = 0; $i < $logs->count(); $i++) {
+            if ($logs[$i]['status'] !== 'todo') {
+                continue;
+            }
+
+            $hasTodo = true;
+            $start = Carbon::parse($logs[$i]['viewed_at']);
+            $end   = isset($logs[$i + 1]) ? Carbon::parse($logs[$i + 1]['viewed_at']) : Carbon::now();
+            $totalDays += $this->workingDaysBetween($start, $end);
+        }
+
+        return $hasTodo ? $totalDays : null;
+    }
+
+    /**
      * Totale CHANGES_REQUESTED ricevuti sulle PR collegate alla story.
      */
     public function prChangeRequestsCount(int $storyId): int

--- a/docs/features/8192-giorni-in-todo-team-performance/notes.md
+++ b/docs/features/8192-giorni-in-todo-team-performance/notes.md
@@ -1,0 +1,19 @@
+> Ticket: oc:8192
+
+# Notes — Mostra metrica "giorni in todo" nella card team performance
+
+## Deviazioni dal piano
+- Colonna "Commit" rimossa durante il review gate su richiesta del developer — non aggiungeva valore significativo alla metrica di performance.
+- Ordine colonne riorganizzato su richiesta: Cycle Time → Todo >1g → Reopen → Reviews → On Time → PR.
+- "Reviews" spostata dopo "Reopen" su richiesta.
+
+## Bug trovati
+- Cache Redis `team_perf_avg_{year}_q{quarter}` conteneva il vecchio aggregato senza `avg_todo_stagnation_days` — necessario svuotarla dopo il deploy (o aspettare TTL 1h).
+
+## Decisioni
+- **Etichetta "Todo >1g"**: `workingDaysBetween` conta giorni lavorativi completi, quindi un ticket in todo per meno di un giorno lavorativo restituisce 0. Per non confondere l'utente con "Giorni in todo" (che implicherebbe anche frazioni di giorno), l'etichetta è stata resa esplicita.
+- **Rendering `>= 1`**: i valori 0 mostrano `-` (indistinguibili da null) perché 0 giorni interi in todo non è informazione utile.
+- **Rollback non atomico accettato**: un rollback del solo PHP senza rollback di `card.js` causerebbe `undefined` invece di `-`. Rischio documentato e accettato consapevolmente.
+
+## Follow-up
+- Cache invalidation automatica: al momento la cache `team_perf_avg` non viene invalidata quando cambiano i dati. Un meccanismo di invalidazione esplicita potrebbe essere utile in futuro.

--- a/docs/features/8192-giorni-in-todo-team-performance/overview.md
+++ b/docs/features/8192-giorni-in-todo-team-performance/overview.md
@@ -1,0 +1,32 @@
+> Ticket: oc:8192
+
+# Mostra metrica "giorni in todo" nella card team performance
+
+## Cosa cambia
+La card Nova team performance espone una nuova metrica: i giorni lavorativi totali trascorsi in stato `todo` per ogni ticket. Appare come colonna nella tabella per-ticket e come KPI aggregato (media per developer, poi media del team) in cima alla card.
+
+## Perché
+Mancava visibilità su quanto tempo i ticket rimangono in attesa prima di essere presi in carico. La metrica aiuta a identificare colli di bottiglia nel processo di assegnazione e prioritizzazione. `StoryMetricsCalculator` aveva già `todoStagnationDays()` (giorni massimi) ma non esposto né usato nella card.
+
+## Requisiti
+- [ ] Aggiungere `todoStagnationTotalDays()` in `StoryMetricsCalculator` che somma tutti gli intervalli in `todo` (non il massimo)
+- [ ] Esporre `todo_stagnation_days` nel payload di `TeamPerformanceController::getTickets()`
+- [ ] Aggiungere `avg_todo_stagnation_days` nell'aggregato developer (`buildAggregate`) e team (`buildTeamAggregate`)
+- [ ] Mostrare la colonna "Giorni in todo" nella tabella per-ticket del componente Vue (null → `—`, 0 → `0`)
+- [ ] Mostrare il KPI "Media giorni in todo" nel blocco aggregato in cima alla card (null → `—`, 0 → `0`)
+- [ ] Nessuna nuova migrazione — la metrica è calcolata dai `StoryLog` esistenti
+
+## Rischi
+- **StoryLog incompleti**: ticket molto vecchi potrebbero non avere log per lo status `todo`, restituendo `null`. Mitigazione: null viene mostrato come `—`, non come `0`, per non inquinare le medie.
+- **Performance**: `todoStagnationTotalDays()` itera i log per ogni ticket — stesso pattern di `cycleTimeMinutes()`, già in produzione senza problemi. La cache in-memory `$logCache` ammortizza le query.
+- **Card.js scritto direttamente**: nessun sorgente Vue, il file compilato è modificato manualmente. Tech debt esistente, non introdotto da questa feature.
+
+## Out of scope
+- Modifica al metodo `todoStagnationDays()` esistente (max) — rimane invariato per non rompere eventuali usi futuri
+- Filtri o drill-down per la nuova metrica
+- Tooltip esplicativo sulla colonna (può essere aggiunto in un ciclo successivo)
+
+## Moduli toccati
+- `app/Services/Metrics/StoryMetricsCalculator.php` — nuovo metodo `todoStagnationTotalDays()`
+- `app/Http/Controllers/Nova/TeamPerformanceController.php` — aggiunta metrica in `getTickets()` e `buildAggregate()`
+- `nova-components/team-performance/dist/js/card.js` — nuova colonna e KPI nel componente Vue

--- a/docs/features/8192-giorni-in-todo-team-performance/plan.md
+++ b/docs/features/8192-giorni-in-todo-team-performance/plan.md
@@ -1,0 +1,287 @@
+> Ticket: oc:8192
+
+# Mostra metrica "giorni in todo" nella card team performance — Piano
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Esporre i giorni lavorativi totali trascorsi in stato `todo` per ogni ticket nella card Nova team performance, sia per-ticket che come KPI aggregato.
+
+**Architecture:** Aggiungere `todoStagnationTotalDays()` in `StoryMetricsCalculator` (somma tutti gli intervalli `todo`), esporlo nel controller, visualizzarlo nel componente Vue `card.js` (modificato direttamente, nessun sorgente).
+
+**Tech Stack:** Laravel 10, PHP 8.1, Vue 3 (compilato in `dist/js/card.js`), PostgreSQL, Docker (`php81_orchestrator`).
+
+## Global Constraints
+
+- Commit convention: `feat(oc:8192): ...`
+- Nessun commit automatico — solo su istruzione esplicita del developer
+- Test eseguiti dentro il container: `docker exec php81_orchestrator php artisan test --filter=<test>`
+- DB di test: `orchestrator_test` (configurato in `phpunit.xml`) — mai `DB_DATABASE=orchestrator`
+- `null` = dato non calcolabile → mostrare `—`; `0` = dato calcolato e pari a zero → mostrare `0`
+- Validare sintassi `card.js` con `node --check` prima del commit
+
+---
+
+### Task 1: `todoStagnationTotalDays()` in `StoryMetricsCalculator`
+
+**Files:**
+- Modify: `app/Services/Metrics/StoryMetricsCalculator.php:125-127`
+- Test: `tests/Unit/Services/Metrics/StoryMetricsCalculatorTest.php`
+
+**Interfaces:**
+- Produces: `todoStagnationTotalDays(int $storyId): ?int` — somma giorni lavorativi di tutti gli intervalli in `todo`; `null` se nessun log `todo` trovato
+
+- [ ] **Step 1: Scrivi i test**
+
+Apri `tests/Unit/Services/Metrics/StoryMetricsCalculatorTest.php` e aggiungi dopo il test `test_todo_stagnation_counts_working_days` (riga 177):
+
+```php
+// --- Todo stagnation total ---
+
+public function test_todo_stagnation_total_sums_multiple_intervals(): void
+{
+    $story = Story::factory()->create();
+    $monday = Carbon::parse('next monday');
+
+    // Primo intervallo: lunedì → mercoledì = 2 giorni
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday, 'changes' => ['status' => 'todo']]);
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(2), 'changes' => ['status' => 'progress']]);
+
+    // Secondo intervallo: venerdì → lunedì successivo = 1 giorno lavorativo
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(4), 'changes' => ['status' => 'todo']]);
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(7), 'changes' => ['status' => 'progress']]);
+
+    $this->assertEquals(3, $this->calc->todoStagnationTotalDays($story->id));
+}
+
+public function test_todo_stagnation_total_returns_null_when_no_todo_logs(): void
+{
+    $story = Story::factory()->create();
+    $monday = Carbon::parse('next monday');
+
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday, 'changes' => ['status' => 'progress']]);
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(2), 'changes' => ['status' => 'done']]);
+
+    $this->assertNull($this->calc->todoStagnationTotalDays($story->id));
+}
+
+public function test_todo_stagnation_total_single_interval(): void
+{
+    $story = Story::factory()->create();
+    $monday = Carbon::parse('next monday');
+
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday, 'changes' => ['status' => 'todo']]);
+    StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(2), 'changes' => ['status' => 'progress']]);
+
+    $this->assertEquals(2, $this->calc->todoStagnationTotalDays($story->id));
+}
+```
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+```bash
+docker exec php81_orchestrator php artisan test --filter=test_todo_stagnation_total
+```
+
+Atteso: FAIL con `Call to undefined method ... todoStagnationTotalDays()`
+
+- [ ] **Step 3: Implementa `todoStagnationTotalDays()`**
+
+In `app/Services/Metrics/StoryMetricsCalculator.php`, aggiungi dopo `todoStagnationDays()` (riga 128):
+
+```php
+/**
+ * Giorni lavorativi totali in cui la story è rimasta in `todo`, sommando tutti gli intervalli.
+ * Restituisce null se non esistono log con status `todo`.
+ */
+public function todoStagnationTotalDays(int $storyId): ?int
+{
+    $logs = $this->getStatusLogs($storyId);
+    $totalDays = 0;
+    $hasTodo = false;
+
+    for ($i = 0; $i < $logs->count(); $i++) {
+        if ($logs[$i]['status'] !== 'todo') {
+            continue;
+        }
+
+        $hasTodo = true;
+        $start = Carbon::parse($logs[$i]['viewed_at']);
+        $end   = isset($logs[$i + 1]) ? Carbon::parse($logs[$i + 1]['viewed_at']) : Carbon::now();
+        $totalDays += $this->workingDaysBetween($start, $end);
+    }
+
+    return $hasTodo ? $totalDays : null;
+}
+```
+
+- [ ] **Step 4: Esegui i test per verificare che passino**
+
+```bash
+docker exec php81_orchestrator php artisan test --filter=test_todo_stagnation_total
+```
+
+Atteso: 3 test PASS
+
+- [ ] **Step 5: Esegui tutta la suite del calculator per verificare nessuna regressione**
+
+```bash
+docker exec php81_orchestrator php artisan test --filter=StoryMetricsCalculatorTest
+```
+
+Atteso: tutti i test esistenti PASS
+
+---
+
+### Task 2: Esponi `todo_stagnation_days` nel controller
+
+**Files:**
+- Modify: `app/Http/Controllers/Nova/TeamPerformanceController.php`
+
+**Interfaces:**
+- Consumes: `StoryMetricsCalculator::todoStagnationTotalDays(int $storyId): ?int`
+- Produces:
+  - `getTickets()` → aggiunge `'todo_stagnation_days' => int|null` per ogni ticket
+  - `buildAggregate()` → aggiunge `'avg_todo_stagnation_days' => float|null`
+  - `buildTeamAggregate()` → aggiunge `'avg_todo_stagnation_days' => float|null`
+
+- [ ] **Step 1: Aggiungi `todo_stagnation_days` in `getTickets()`**
+
+In `TeamPerformanceController::getTickets()`, nel return del `map()` (intorno alla riga 104-117), aggiungi la riga dopo `'change_requests_count'`:
+
+```php
+'todo_stagnation_days'  => $this->calc->todoStagnationTotalDays($story->id),
+```
+
+Il blocco completo del return diventa:
+
+```php
+return [
+    'id'                    => $story->id,
+    'name'                  => $story->name,
+    'type'                  => $story->type,
+    'nova_url'              => '/resources/customer-stories/' . $story->id,
+    'cycle_time_hours'      => $cycleMinutes !== null ? round($cycleMinutes / 60, 1) : null,
+    'reopen_count'          => $this->calc->reopenCount($story->id),
+    'on_time'               => $this->calc->onTimeDelivery($story->id, $teamAvgCycleMinutes),
+    'on_time_diff_hours'    => $this->onTimeDiff($story->id, $teamAvgCycleMinutes),
+    'on_time_detail'        => $this->onTimeDetail($story, $teamAvgCycleMinutes),
+    'commit_count'          => $commits ?: null,
+    'pr_count'              => $prs->count() ?: null,
+    'change_requests_count' => $prs->sum('change_requests_count') ?: null,
+    'todo_stagnation_days'  => $this->calc->todoStagnationTotalDays($story->id),
+];
+```
+
+- [ ] **Step 2: Aggiungi `avg_todo_stagnation_days` in `buildAggregate()`**
+
+Nel metodo `buildAggregate()`, aggiungi dopo la riga `$changeReqs`:
+
+```php
+$todoStagnation = array_filter(array_column($tickets, 'todo_stagnation_days'), fn ($v) => $v !== null);
+```
+
+Nel return di `buildAggregate()` (caso vuoto, intorno riga 178-185), aggiungi:
+
+```php
+'avg_todo_stagnation_days' => null,
+```
+
+Nel return del caso non vuoto (intorno riga 196-205), aggiungi:
+
+```php
+'avg_todo_stagnation_days' => count($todoStagnation) ? round(array_sum($todoStagnation) / count($todoStagnation), 1) : null,
+```
+
+- [ ] **Step 3: Aggiungi `avg_todo_stagnation_days` in `buildTeamAggregate()`**
+
+Nel return del caso vuoto (riga 231), aggiungi `'avg_todo_stagnation_days' => null` alla lista:
+
+```php
+return ['story_count' => 0, 'avg_cycle_time_hours' => null, 'avg_reopen_count' => null, 'on_time_rate' => null, 'avg_commit_count' => null, 'avg_pr_count' => null, 'avg_change_requests' => null, 'avg_todo_stagnation_days' => null];
+```
+
+Nel return del caso non vuoto (intorno riga 236-245), aggiungi:
+
+```php
+'avg_todo_stagnation_days' => $avg('avg_todo_stagnation_days') !== null ? round($avg('avg_todo_stagnation_days'), 1) : null,
+```
+
+- [ ] **Step 4: Verifica manuale che il controller restituisca il campo**
+
+```bash
+docker exec php81_orchestrator php artisan tinker --execute="
+use App\Http\Controllers\Nova\TeamPerformanceController;
+use App\Services\Metrics\StoryMetricsCalculator;
+\$ctrl = new TeamPerformanceController(new StoryMetricsCalculator());
+echo 'Controller instanziato correttamente';
+"
+```
+
+Atteso: nessun errore PHP
+
+---
+
+### Task 3: Colonna e KPI nel componente Vue `card.js`
+
+**Files:**
+- Modify: `nova-components/team-performance/dist/js/card.js`
+
+**Interfaces:**
+- Consumes: `ticket.todo_stagnation_days` (int|null), `aggregate.developer.avg_todo_stagnation_days` (float|null), `aggregate.team_average.avg_todo_stagnation_days` (float|null)
+
+- [ ] **Step 1: Aggiungi intestazione colonna nella `<thead>`**
+
+Cerca la riga contenente:
+
+```
+<th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Numero totale di review ricevute sulle PR collegate (commenti, approvazioni, richieste di modifica).">Reviews ⓘ</th>
+```
+
+Aggiungi **dopo** quella riga (prima di `</thead>`):
+
+```
+<th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Totale giorni lavorativi trascorsi in stato todo prima di essere presi in carico. Somma di tutti gli intervalli todo nella storia del ticket.">Giorni in todo ⓘ</th>
+```
+
+- [ ] **Step 2: Aggiungi cella dati per-ticket nel `<tbody>`**
+
+Cerca la riga contenente `ticket.change_requests_count` nella sezione `<tbody>` (intorno a riga 100-105 del file). Aggiungi **dopo** quella `<td>`:
+
+```
+<td class="py-2 px-3 text-center text-gray-700 dark:text-gray-300">{{ ticket.todo_stagnation_days !== null ? ticket.todo_stagnation_days : '-' }}</td>
+```
+
+- [ ] **Step 3: Aggiungi cella KPI media team**
+
+Cerca il blocco dei KPI della riga "Team" (quella con `aggregate.team_average.avg_change_requests`). Aggiungi **dopo** quella `<td>`:
+
+```
+<td class="py-3 px-3 text-center">{{ aggregate.team_average.avg_todo_stagnation_days !== null ? aggregate.team_average.avg_todo_stagnation_days : '-' }}</td>
+```
+
+- [ ] **Step 4: Aggiungi cella KPI developer**
+
+Cerca il blocco dei KPI della riga "Developer" (quella con `aggregate.developer.avg_change_requests`). Aggiungi **dopo** quella `<td>`:
+
+```
+<td class="py-3 px-3 text-center" :class="deltaClass(aggregate.developer.avg_todo_stagnation_days, aggregate.team_average.avg_todo_stagnation_days, true)" style="cursor:help" title="Media giorni in todo del developer. Verde = meno giorni della media team, rosso = più giorni.">
+    {{ aggregate.developer.avg_todo_stagnation_days !== null ? aggregate.developer.avg_todo_stagnation_days : '-' }}
+    <span v-if="aggregate.developer.avg_todo_stagnation_days !== null && aggregate.team_average.avg_todo_stagnation_days !== null" class="text-xs ml-1">{{ delta(aggregate.developer.avg_todo_stagnation_days, aggregate.team_average.avg_todo_stagnation_days) }}</span>
+</td>
+```
+
+- [ ] **Step 5: Valida la sintassi del file**
+
+```bash
+node --check nova-components/team-performance/dist/js/card.js
+```
+
+Atteso: nessun output (nessun errore sintattico)
+
+- [ ] **Step 6: Verifica visiva nel browser**
+
+Apri la card team performance in Nova (`/nova/dashboards/team-performance`), verifica che:
+- La colonna "Giorni in todo" appaia nella tabella
+- I valori numerici o `—` siano mostrati correttamente
+- Il KPI "Media giorni in todo" appaia nella riga aggregato team e developer
+- Il colore verde/rosso funzioni correttamente rispetto alla media team

--- a/nova-components/team-performance/dist/js/card.js
+++ b/nova-components/team-performance/dist/js/card.js
@@ -55,11 +55,11 @@ Nova.booting(function (app) {
                     <th class="text-left py-3 px-3 font-semibold text-gray-600 dark:text-gray-400">Ticket</th>
                     <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400">Tipo</th>
                     <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Minuti totali trascorsi in stato 'progress'. Esclude il tempo in altri stati (todo, testing, ecc.). Fonte: StoryLog.">Cycle Time ⓘ</th>
+                    <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Totale giorni lavorativi trascorsi in stato todo prima di essere presi in carico. Somma di tutti gli intervalli todo nella storia del ticket.">Todo >1g ⓘ</th>
                     <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Numero di volte che il ticket è tornato a progress/todo da uno stato avanzato (testing, tested, released). Indica rilavorazioni.">Reopen ⓘ</th>
-                    <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="✓ se il cycle time è entro il benchmark. Benchmark: ore stimate × 60 min se presenti, altrimenti media del cycle time del team nel quarter.">On Time ⓘ</th>
-                    <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Numero di commit su GitHub che richiamano questo ticket (pattern: oc seguito da max 3 caratteri e poi il numero, es. oc:1234, oc-1234).">Commit ⓘ</th>
-                    <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Numero di Pull Request su GitHub collegate al ticket.">PR ⓘ</th>
                     <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Numero totale di review ricevute sulle PR collegate (commenti, approvazioni, richieste di modifica).">Reviews ⓘ</th>
+                    <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="✓ se il cycle time è entro il benchmark. Benchmark: ore stimate × 60 min se presenti, altrimenti media del cycle time del team nel quarter.">On Time ⓘ</th>
+                    <th class="text-center py-3 px-3 font-semibold text-gray-600 dark:text-gray-400" style="cursor:help" title="Numero di Pull Request su GitHub collegate al ticket.">PR ⓘ</th>
                 </tr>
             </thead>
             <tbody>
@@ -81,10 +81,14 @@ Nova.booting(function (app) {
                     <td class="py-3 px-3 text-center text-gray-700 dark:text-gray-300">
                         <span :class="ticket.cycle_time_hours >= 80 ? 'text-red-500 font-semibold' : ''">{{ ticket.cycle_time_hours !== null ? ticket.cycle_time_hours + (ticket.cycle_time_hours >= 80 ? 'h+' : 'h') : '-' }}</span>
                     </td>
+                    <td class="py-2 px-3 text-center text-gray-700 dark:text-gray-300">{{ ticket.todo_stagnation_days >= 1 ? ticket.todo_stagnation_days : '-' }}</td>
                     <td class="py-3 px-3 text-center">
                         <span :class="ticket.reopen_count > 0 ? 'text-red-600 dark:text-red-400 font-semibold' : 'text-gray-500 dark:text-gray-400'">
                             {{ ticket.reopen_count }}
                         </span>
+                    </td>
+                    <td class="py-3 px-3 text-center text-gray-700 dark:text-gray-300">
+                        {{ ticket.change_requests_count !== null ? ticket.change_requests_count : '-' }}
                     </td>
                     <td class="py-3 px-3 text-center" style="cursor:help" :title="ticket.on_time_detail || ''">
                         <span v-if="ticket.on_time === true" class="text-green-500 text-lg">&#10003;</span>
@@ -97,13 +101,7 @@ Nova.booting(function (app) {
                         </span>
                     </td>
                     <td class="py-3 px-3 text-center text-gray-700 dark:text-gray-300">
-                        {{ ticket.commit_count !== null ? ticket.commit_count : '-' }}
-                    </td>
-                    <td class="py-3 px-3 text-center text-gray-700 dark:text-gray-300">
                         {{ ticket.pr_count !== null ? ticket.pr_count : '-' }}
-                    </td>
-                    <td class="py-3 px-3 text-center text-gray-700 dark:text-gray-300">
-                        {{ ticket.change_requests_count !== null ? ticket.change_requests_count : '-' }}
                     </td>
                 </tr>
             </tbody>
@@ -118,20 +116,18 @@ Nova.booting(function (app) {
                     <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400" style="cursor:help" title="Media del cycle time (tempo attivo in progress) di tutti i developer nel quarter">
                         {{ aggregate.team_average.avg_cycle_time_hours !== null ? aggregate.team_average.avg_cycle_time_hours + 'h' : '-' }}
                     </td>
+                    <td class="py-3 px-3 text-center">{{ aggregate.team_average.avg_todo_stagnation_days !== null ? aggregate.team_average.avg_todo_stagnation_days : '-' }}</td>
                     <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400" style="cursor:help" title="Media del numero di riaperture per ticket di tutti i developer nel quarter">
                         {{ aggregate.team_average.avg_reopen_count !== null ? aggregate.team_average.avg_reopen_count : '-' }}
+                    </td>
+                    <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400">
+                        {{ aggregate.team_average.avg_change_requests !== null ? aggregate.team_average.avg_change_requests : '-' }}
                     </td>
                     <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400" style="cursor:help" title="% di ticket completati entro il benchmark (ore stimate o media cycle time team) sul totale dei ticket con cycle time misurabile">
                         {{ aggregate.team_average.on_time_rate !== null ? aggregate.team_average.on_time_rate + '%' : '-' }}
                     </td>
                     <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400">
-                        {{ aggregate.team_average.avg_commit_count !== null ? aggregate.team_average.avg_commit_count : '-' }}
-                    </td>
-                    <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400">
                         {{ aggregate.team_average.avg_pr_count !== null ? aggregate.team_average.avg_pr_count : '-' }}
-                    </td>
-                    <td class="py-3 px-3 text-center text-gray-600 dark:text-gray-400">
-                        {{ aggregate.team_average.avg_change_requests !== null ? aggregate.team_average.avg_change_requests : '-' }}
                     </td>
                 </tr>
 
@@ -146,22 +142,23 @@ Nova.booting(function (app) {
                         {{ aggregate.developer.avg_cycle_time_hours !== null ? aggregate.developer.avg_cycle_time_hours + 'h' : '-' }}
                         <span v-if="aggregate.developer.avg_cycle_time_hours !== null && aggregate.team_average.avg_cycle_time_hours !== null" class="text-xs ml-1">{{ delta(aggregate.developer.avg_cycle_time_hours, aggregate.team_average.avg_cycle_time_hours) }}</span>
                     </td>
+                    <td class="py-3 px-3 text-center" :class="deltaClass(aggregate.developer.avg_todo_stagnation_days, aggregate.team_average.avg_todo_stagnation_days, true)" style="cursor:help" title="Media giorni in todo del developer. Verde = meno giorni della media team, rosso = più giorni.">
+                        {{ aggregate.developer.avg_todo_stagnation_days !== null ? aggregate.developer.avg_todo_stagnation_days : '-' }}
+                        <span v-if="aggregate.developer.avg_todo_stagnation_days !== null && aggregate.team_average.avg_todo_stagnation_days !== null" class="text-xs ml-1">{{ delta(aggregate.developer.avg_todo_stagnation_days, aggregate.team_average.avg_todo_stagnation_days) }}</span>
+                    </td>
                     <td class="py-3 px-3 text-center" :class="deltaClass(aggregate.developer.avg_reopen_count, aggregate.team_average.avg_reopen_count, true)" style="cursor:help" title="Media riaperture per ticket del developer. Verde = meno riaperture della media team, rosso = più riaperture.">
                         {{ aggregate.developer.avg_reopen_count !== null ? aggregate.developer.avg_reopen_count : '-' }}
                         <span v-if="aggregate.developer.avg_reopen_count !== null && aggregate.team_average.avg_reopen_count !== null" class="text-xs ml-1">{{ delta(aggregate.developer.avg_reopen_count, aggregate.team_average.avg_reopen_count) }}</span>
+                    </td>
+                    <td class="py-3 px-3 text-center text-blue-700 dark:text-blue-300">
+                        {{ aggregate.developer.avg_change_requests !== null ? aggregate.developer.avg_change_requests : '-' }}
                     </td>
                     <td class="py-3 px-3 text-center" :class="deltaClass(aggregate.developer.on_time_rate, aggregate.team_average.on_time_rate, false)" style="cursor:help" title="% ticket completati in tempo dal developer. Verde = sopra la media team, rosso = sotto. Il diff mostra la distanza dalla media.">
                         {{ aggregate.developer.on_time_rate !== null ? aggregate.developer.on_time_rate + '%' : '-' }}
                         <span v-if="aggregate.developer.on_time_rate !== null && aggregate.team_average.on_time_rate !== null" class="text-xs ml-1">{{ delta(aggregate.developer.on_time_rate, aggregate.team_average.on_time_rate) }}</span>
                     </td>
                     <td class="py-3 px-3 text-center text-blue-700 dark:text-blue-300">
-                        {{ aggregate.developer.avg_commit_count !== null ? aggregate.developer.avg_commit_count : '-' }}
-                    </td>
-                    <td class="py-3 px-3 text-center text-blue-700 dark:text-blue-300">
                         {{ aggregate.developer.avg_pr_count !== null ? aggregate.developer.avg_pr_count : '-' }}
-                    </td>
-                    <td class="py-3 px-3 text-center text-blue-700 dark:text-blue-300">
-                        {{ aggregate.developer.avg_change_requests !== null ? aggregate.developer.avg_change_requests : '-' }}
                     </td>
                 </tr>
             </tfoot>

--- a/tests/Unit/Services/Metrics/StoryMetricsCalculatorTest.php
+++ b/tests/Unit/Services/Metrics/StoryMetricsCalculatorTest.php
@@ -175,4 +175,44 @@ class StoryMetricsCalculatorTest extends TestCase
 
         $this->assertEquals(2, $this->calc->todoStagnationDays($story->id));
     }
+
+    // --- Todo stagnation total ---
+
+    public function test_todo_stagnation_total_sums_multiple_intervals(): void
+    {
+        $story = Story::factory()->create();
+        $monday = Carbon::parse('next monday');
+
+        // Primo intervallo: lunedì → mercoledì = 2 giorni
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday, 'changes' => ['status' => 'todo']]);
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(2), 'changes' => ['status' => 'progress']]);
+
+        // Secondo intervallo: venerdì → lunedì successivo = 1 giorno lavorativo
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(4), 'changes' => ['status' => 'todo']]);
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(7), 'changes' => ['status' => 'progress']]);
+
+        $this->assertEquals(3, $this->calc->todoStagnationTotalDays($story->id));
+    }
+
+    public function test_todo_stagnation_total_returns_null_when_no_todo_logs(): void
+    {
+        $story = Story::factory()->create();
+        $monday = Carbon::parse('next monday');
+
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday, 'changes' => ['status' => 'progress']]);
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(2), 'changes' => ['status' => 'done']]);
+
+        $this->assertNull($this->calc->todoStagnationTotalDays($story->id));
+    }
+
+    public function test_todo_stagnation_total_single_interval(): void
+    {
+        $story = Story::factory()->create();
+        $monday = Carbon::parse('next monday');
+
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday, 'changes' => ['status' => 'todo']]);
+        StoryLog::create(['story_id' => $story->id, 'user_id' => $this->user->id, 'viewed_at' => $monday->copy()->addDays(2), 'changes' => ['status' => 'progress']]);
+
+        $this->assertEquals(2, $this->calc->todoStagnationTotalDays($story->id));
+    }
 }


### PR DESCRIPTION
## Summary
- Nuovo metodo `todoStagnationTotalDays()` in `StoryMetricsCalculator` che somma tutti gli intervalli in stato `todo` (giorni lavorativi interi)
- Esposto in `TeamPerformanceController` come `todo_stagnation_days` per-ticket e `avg_todo_stagnation_days` negli aggregati developer/team
- Visualizzato in `card.js` come colonna "Todo >1g" (dopo Cycle Time) e KPI con delta colorato; valori 0 mostrati come `—`; colonna Commit rimossa

## Test plan
- [ ] 16 test `StoryMetricsCalculatorTest` passano (inclusi 3 nuovi per `todoStagnationTotalDays`)
- [ ] Aprire la card team performance e verificare la colonna "Todo >1g" nella tabella
- [ ] Verificare KPI aggregato developer e media team
- [ ] Svuotare cache Redis se i valori team non appaiono: `Cache::forget('team_perf_avg_{year}_q{quarter}')`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)